### PR TITLE
Release/main/6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,22 @@ GET https://customer01.yourapp.io/auth/login?login_hint=user@wristband.dev
 
 If Wristband passes this parameter, it will be appended as part of the redirect request to the Wristband Authorize Endpoint. Typically, the email form field on the Tenant-Level Login page is pre-filled when a user has previously entered their email on the Application-Level Login Page.
 
+#### IDP Hints
+
+If you want to bypass the Wristband-hosted Tenant Login Page entirely and send users directly to a specific identity provider's login page, you can pass the `idp_hint` query parameter to your Login Endpoint:
+
+```sh
+GET https://customer01.yourapp.io/auth/login?idp_hint=google
+```
+
+The value should be the `name` field of an identity provider that is currently enabled for the tenant. When Wristband receives this hint, it checks if the provided IdP name matches an enabled identity provider for that tenant:
+
+- **Matching external IdP (e.g. `google`)** — Wristband skips the Tenant Login Page entirely and redirects the user straight to that external IdP's login page (e.g. Google's login page).
+- **Wristband IdP name** — Wristband displays the Tenant Login Page but shows only the Wristband email-based login form, hiding any external IdP buttons.
+- **Unrecognized or invalid value** — Wristband ignores the hint and displays the Tenant Login Page as normal.
+
+This is useful when your application already knows which identity provider a user should authenticate with, allowing you to skip the IdP selection step entirely and provide a more seamless login experience.
+
 #### Return URLs
 
 It is possible that users will try to access a location within your application that is not some default landing page. In those cases, they would expect to immediately land back at that desired location after logging in.  This is a better experience for the user, especially in cases where they have application URLs bookmarked for convenience.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@wristband/express-auth",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wristband/express-auth",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@wristband/typescript-jwt": "^0.2.3",
         "@wristband/typescript-session": "^0.1.0",
-        "axios": "^1.13.2",
         "iron-webcrypto": "^1.2.1",
         "uncrypto": "^0.1.3"
       },
@@ -34,7 +33,6 @@
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
-        "nock": "^13.5.4",
         "node-mocks-http": "^1.14.1",
         "pinst": "^3.0.0",
         "ts-jest": "^29.3.2",
@@ -612,29 +610,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -659,30 +634,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -994,17 +945,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1023,18 +963,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1483,25 +1411,24 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.2.0.tgz",
-      "integrity": "sha512-mdekAHOqS9UjlmyF/LSs6AIEvfceV749GFxoBAjwAv0nkevfKHWQFDMcBZWUiIC5ft6ePWivXoS36aKQ0Cy3sw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/type-utils": "7.2.0",
-        "@typescript-eslint/utils": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1518,19 +1445,20 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1546,16 +1474,17 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0"
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1563,18 +1492,19 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.2.0.tgz",
-      "integrity": "sha512-xHi51adBHo9O9330J8GQYQwrKBqbIPJGZZVQTHHmy200hvkLZFWJIFtAG/7IYTWUyun6DE6w5InDReePJYJlJA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/utils": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1590,12 +1520,13 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1603,22 +1534,23 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1630,22 +1562,36 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.2.0.tgz",
-      "integrity": "sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "semver": "^7.5.4"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1656,16 +1602,17 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1733,10 +1680,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1965,11 +1913,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1983,17 +1926,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2309,6 +2241,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2467,22 +2400,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -2654,14 +2577,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2718,6 +2633,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2859,6 +2775,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2868,6 +2785,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2876,6 +2794,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2888,6 +2807,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3160,17 +3080,6 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -3190,18 +3099,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -3370,29 +3267,6 @@
         "eslint": ">=5.16.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/eslint-plugin-node/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3482,29 +3356,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -3887,9 +3738,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3964,29 +3815,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -3995,22 +3828,6 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -4056,6 +3873,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4109,6 +3927,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4142,6 +3961,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4246,6 +4066,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4312,6 +4133,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4324,6 +4146,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4338,6 +4161,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4891,30 +4715,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -5065,17 +4865,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/jest-config/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5094,18 +4883,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-config/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jest-diff": {
@@ -5409,17 +5186,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5438,18 +5204,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jest-snapshot": {
@@ -5633,12 +5387,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5767,6 +5515,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5843,6 +5592,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5851,6 +5601,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5868,18 +5619,27 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {
@@ -5911,20 +5671,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
       }
     },
     "node_modules/node-int64": {
@@ -6334,10 +6080,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6516,15 +6263,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6538,11 +6276,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6570,9 +6303,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6756,17 +6489,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6785,18 +6507,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/router": {
@@ -7371,17 +7081,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -7400,18 +7099,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -945,26 +945,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1158,6 +1138,13 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -1767,13 +1754,14 @@
       "dev": true
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1783,16 +1771,20 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
-      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-string": "^1.0.7"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1810,36 +1802,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/array.prototype.filter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-      "integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz",
-      "integrity": "sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1849,15 +1825,16 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1867,15 +1844,16 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1885,19 +1863,19 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1906,18 +1884,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -2219,16 +2201,16 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2496,6 +2478,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2651,22 +2687,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.702",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.702.tgz",
@@ -2711,52 +2731,66 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.5.tgz",
-      "integrity": "sha512-oW69R+4q2wG+Hc3KZePPZxOiisRIqfKBVo/HLx94QcJeWGU/8sZhCvc829rd1kS366vlJbzBfXf9yWwf0+Ko7w==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "es-define-property": "^1.0.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
-        "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
-        "gopd": "^1.0.1",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.1",
-        "internal-slot": "^1.0.7",
-        "is-array-buffer": "^3.0.4",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
         "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
-        "safe-array-concat": "^1.1.0",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.8",
-        "string.prototype.trimend": "^1.0.7",
-        "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.5",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.14"
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2764,12 +2798,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2820,23 +2848,28 @@
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3005,10 +3038,11 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
-      "integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7"
       },
@@ -3026,6 +3060,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -3050,34 +3085,37 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
-      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.7",
-        "array.prototype.findlastindex": "^1.2.3",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.8.0",
-        "hasown": "^2.0.0",
-        "is-core-module": "^2.13.1",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.7",
-        "object.groupby": "^1.0.1",
-        "object.values": "^1.1.7",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
         "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -3111,10 +3149,11 @@
       }
     },
     "node_modules/eslint-plugin-jest-extended": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-extended/-/eslint-plugin-jest-extended-2.0.0.tgz",
-      "integrity": "sha512-nMhVVsVcG/+Q6FMshql35WBxwx8xlBhxKgAG08WP3BYWfXrp28oxLpJVu9JSbMpfmfKGVrHwMYJGfPLRKlGB8w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-extended/-/eslint-plugin-jest-extended-2.4.0.tgz",
+      "integrity": "sha512-olotsH4SczpKgH/EPQZVp3jJ+YpMCsO0wNEMIx09C2/5HC0CtPrxSZ4BzPd/iZsD3bIOgO7H9e3KXVojvoMYsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
       },
@@ -3122,7 +3161,7 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-jest-extended/node_modules/@typescript-eslint/scope-manager": {
@@ -3727,29 +3766,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3822,12 +3838,19 @@
       "license": "ISC"
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -3879,15 +3902,18 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3901,8 +3927,19 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -3984,20 +4021,43 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -4028,12 +4088,14 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4087,11 +4149,37 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4118,10 +4206,14 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4307,14 +4399,15 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4339,13 +4432,15 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4360,26 +4455,51 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
-    "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-bigints": "^1.0.1"
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4393,6 +4513,7 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4401,24 +4522,48 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4434,6 +4579,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -4454,6 +4615,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4464,6 +4645,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-negative-zero": {
@@ -4488,12 +4682,14 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4519,13 +4715,16 @@
       "license": "MIT"
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4534,13 +4733,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4562,12 +4775,14 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4577,12 +4792,15 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4592,12 +4810,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4606,13 +4825,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4622,7 +4875,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4694,25 +4948,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -4863,26 +5098,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-config/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-diff": {
@@ -5184,26 +5399,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-snapshot": {
@@ -5673,6 +5868,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5810,14 +6012,17 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -5842,14 +6047,16 @@
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
-      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5859,27 +6066,31 @@
       }
     },
     "node_modules/object.groupby": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.2.tgz",
-      "integrity": "sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array.prototype.filter": "^1.0.3",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.0.0"
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
-      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5940,6 +6151,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -6179,10 +6408,11 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -6369,16 +6599,42 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
-        "set-function-name": "^2.0.1"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6489,26 +6745,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -6550,14 +6786,16 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -6587,15 +6825,33 @@
         }
       ]
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6612,9 +6868,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6722,11 +6978,27 @@
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6913,6 +7185,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6941,14 +7227,19 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6958,28 +7249,37 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7081,26 +7381,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7148,21 +7428,20 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
-      "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
+        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.1",
-        "type-fest": "^4.39.1",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -7173,10 +7452,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -7194,13 +7474,16 @@
         },
         "esbuild": {
           "optional": true
+        },
+        "jest-util": {
+          "optional": true
         }
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
-      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -7317,30 +7600,32 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7350,17 +7635,19 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7370,17 +7657,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.5.tgz",
-      "integrity": "sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0"
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7403,16 +7691,34 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7528,31 +7834,85 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -7561,6 +7921,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@wristband/express-auth",
   "description": "SDK for integrating your ExpressJS application with Wristband. Handles user authentication, session management, and token management.",
   "author": "Wristband",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "license": "MIT",
   "private": false,
   "homepage": "https://wristband.dev",
@@ -112,7 +112,6 @@
     "husky": "^9.0.11",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
-    "nock": "^13.5.4",
     "node-mocks-http": "^1.14.1",
     "pinst": "^3.0.0",
     "ts-jest": "^29.3.2",
@@ -121,7 +120,6 @@
   "dependencies": {
     "@wristband/typescript-jwt": "^0.2.3",
     "@wristband/typescript-session": "^0.1.0",
-    "axios": "^1.13.2",
     "iron-webcrypto": "^1.2.1",
     "uncrypto": "^0.1.3"
   }

--- a/src/auth-service.ts
+++ b/src/auth-service.ts
@@ -1,5 +1,4 @@
 import { NextFunction, Request, Response } from 'express';
-import { AxiosError } from 'axios';
 import {
   createWristbandJwtValidator,
   WristbandJwtValidatorConfig,
@@ -40,7 +39,7 @@ import {
   UserInfo,
   WristbandTokenResponse,
 } from './types';
-import { InvalidGrantError, WristbandError } from './error';
+import { FetchError, InvalidGrantError, WristbandError } from './error';
 import { ConfigResolver } from './config-resolver';
 import { isValidCsrf, normalizeAuthMiddlewareConfig, sendAuthFailureResponse } from './utils/middleware';
 
@@ -402,23 +401,25 @@ export class AuthService {
       } catch (error: unknown) {
         // Specifically handle invalid_grant errors
         if (error instanceof InvalidGrantError) {
-          throw error;
+          throw new WristbandError('invalid_refresh_token', error.errorDescription, error);
         }
 
         // Only 4xx errors should short-circuit the retry loop early.
         if (
-          error instanceof AxiosError &&
+          error instanceof FetchError &&
           error.response &&
           error.response.status >= 400 &&
           error.response.status < 500
         ) {
-          const errorDescription = error.response.data?.error_description ?? 'Invalid Refresh Token';
-          throw new WristbandError('invalid_refresh_token', errorDescription);
+          // Only 4xx errors should short-circuit the retry loop early.
+          const errorDescription =
+            error.body && error.body.error_description ? error.body.error_description : 'Invalid Refresh Token';
+          throw new WristbandError('invalid_refresh_token', errorDescription, error);
         }
 
         // Last attempt failed
         if (attempt === MAX_REFRESH_ATTEMPTS) {
-          throw new WristbandError('unexpected_error', 'Unexpected Error');
+          throw new WristbandError('unexpected_error', 'Unexpected Error', error instanceof Error ? error : undefined);
         }
 
         // Wait before next retry (only for 5xx errors or network failures)

--- a/src/config-resolver.ts
+++ b/src/config-resolver.ts
@@ -182,19 +182,21 @@ export class ConfigResolver {
 
   // Method to preload and validate all configurations
   private validateAllDynamicConfigs(sdkConfiguration: SdkConfiguration): void {
-    // Validate that required fields are present in the SDK config response
-    if (!sdkConfiguration.loginUrl) {
-      throw new WristbandError('SDK configuration response missing required field: loginUrl');
-    }
-    if (!sdkConfiguration.redirectUri) {
-      throw new WristbandError('SDK configuration response missing required field: redirectUri');
-    }
-
     // Use manual config values if provided, otherwise use SDK config values
-    const loginUrl = this.authConfig.loginUrl || sdkConfiguration.loginUrl;
-    const redirectUri = this.authConfig.redirectUri || sdkConfiguration.redirectUri;
+    const loginUrl = this.authConfig.loginUrl || sdkConfiguration.loginUrl || '';
+    const redirectUri = this.authConfig.redirectUri || sdkConfiguration.redirectUri || '';
     const parseTenantFromRootDomain =
       this.authConfig.parseTenantFromRootDomain || sdkConfiguration.loginUrlTenantDomainSuffix || '';
+
+    // Validate that required fields are present in the SDK config response
+    if (!loginUrl) {
+      throw new WristbandError('SDK configuration response missing required field: loginUrl');
+    }
+    if (!redirectUri) {
+      throw new WristbandError(
+        'The [redirectUri] could not be resolved. Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.'
+      );
+    }
 
     // Validate the tenant name placeholder logic with final resolved values
     if (parseTenantFromRootDomain) {

--- a/src/error/fetch-error.ts
+++ b/src/error/fetch-error.ts
@@ -1,0 +1,31 @@
+/**
+ * Represents an error that occurs during a fetch request.
+ *
+ * Wraps both the raw {@link Response} object and its parsed body,
+ * providing structured access to error details returned by the server.
+ *
+ * @template Response - The type of the underlying fetch response object.
+ */
+export class FetchError<Response> extends Error {
+  /**
+   * The raw Response object returned from the fetch request.
+   */
+  readonly response?: Response;
+  /**
+   * The parsed response body, typically JSON or text, if available.
+   */
+  readonly body?: any;
+
+  /**
+   * Creates a new FetchError instance.
+   *
+   * @param response - The raw fetch Response associated with the error.
+   * @param body - The parsed body of the response, if available.
+   */
+  constructor(response: Response, body: any) {
+    super('Fetch Error');
+    this.name = 'FetchError';
+    this.response = response;
+    this.body = body;
+  }
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,2 +1,3 @@
+export * from './fetch-error';
 export * from './invalid-grant-error';
 export * from './wristband-error';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,16 @@ import { LOGIN_STATE_COOKIE_PREFIX, LOGIN_STATE_COOKIE_SEPARATOR } from './const
 import { LoginState, LoginStateMapConfig } from '../types';
 import { clearCookie, parseCookies, setCookie } from './cookies';
 
+export function encodeBase64(input: string) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  let binary = '';
+  data.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
 export function parseTenantSubdomain(req: Request, parseTenantFromRootDomain: string): string {
   const { host } = req.headers;
 
@@ -179,7 +189,11 @@ export function getOAuthAuthorizeUrl(
     wristbandApplicationVanityDomain: string;
   }
 ): string {
-  const { login_hint: loginHint } = req.query;
+  const { idp_hint: idpHint, login_hint: loginHint } = req.query;
+
+  if (!!idpHint && typeof idpHint !== 'string') {
+    throw new TypeError('More than one [idp_hint] query parameter was encountered');
+  }
 
   if (!!loginHint && typeof loginHint !== 'string') {
     throw new TypeError('More than one [login_hint] query parameter was encountered');
@@ -194,6 +208,7 @@ export function getOAuthAuthorizeUrl(
     code_challenge: base64URLEncode(createHash('sha256').update(config.codeVerifier).digest('base64')),
     code_challenge_method: 'S256',
     nonce: generateRandomString(32),
+    ...(!!idpHint && typeof idpHint === 'string' ? { idp_hint: idpHint } : {}),
     ...(!!loginHint && typeof loginHint === 'string' ? { login_hint: loginHint } : {}),
   });
 

--- a/src/wristband-api-client.ts
+++ b/src/wristband-api-client.ts
@@ -1,33 +1,72 @@
-import axios, { AxiosInstance } from 'axios';
-import http from 'http';
-import https from 'https';
-
+import { FetchError } from './error/fetch-error';
 import { FORM_URLENCODED_MEDIA_TYPE, JSON_MEDIA_TYPE } from './utils/constants';
 
+interface RequestOptions extends RequestInit {
+  headers?: HeadersInit;
+  body?: any;
+}
+
+/**
+ * Thin fetch-based HTTP client for the Wristband API.
+ *
+ * Wraps native `fetch` (Node 20+) with a base URL, default headers, and
+ * structured error handling. Non-2xx responses are thrown as {@link FetchError}
+ * instances carrying both the raw `Response` and the parsed body.
+ */
 export class WristbandApiClient {
-  public axiosInstance: AxiosInstance;
+  private readonly baseURL: string;
+  private readonly defaultHeaders: HeadersInit;
 
   constructor(wristbandApplicationVanityDomain: string) {
-    this.axiosInstance = axios.create({
-      baseURL: `https://${wristbandApplicationVanityDomain}/api/v1`,
-      httpAgent: new http.Agent({
-        keepAlive: true,
-        maxSockets: 100,
-        maxFreeSockets: 10,
-        timeout: 60000,
-        keepAliveMsecs: 1000,
-        scheduling: 'lifo',
-      }),
-      httpsAgent: new https.Agent({
-        keepAlive: true,
-        maxSockets: 100,
-        maxFreeSockets: 10,
-        timeout: 60000,
-        keepAliveMsecs: 1000,
-        scheduling: 'lifo',
-      }),
-      headers: { 'Content-Type': FORM_URLENCODED_MEDIA_TYPE, Accept: JSON_MEDIA_TYPE },
-      maxRedirects: 0,
-    });
+    this.baseURL = `https://${wristbandApplicationVanityDomain}/api/v1`;
+    this.defaultHeaders = {
+      'Content-Type': FORM_URLENCODED_MEDIA_TYPE,
+      Accept: JSON_MEDIA_TYPE,
+    };
+  }
+
+  private async request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    const url = `${this.baseURL}${endpoint}`;
+    const headers = { ...this.defaultHeaders, ...options.headers };
+    const config: RequestInit = { ...options, headers };
+    const response = await fetch(url, config);
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const responseBodyText = await response.text();
+    const responseBody = responseBodyText ? (JSON.parse(responseBodyText) as T) : (undefined as T);
+
+    if (response.status >= 400) {
+      throw new FetchError(response, responseBody);
+    }
+
+    return responseBody;
+  }
+
+  /**
+   * Performs a GET request to the given API endpoint.
+   *
+   * @param endpoint - Path relative to the base URL.
+   * @param headers - Optional additional or override headers.
+   * @returns The parsed JSON response body.
+   * @throws {FetchError} On non-2xx responses.
+   */
+  public async get<T>(endpoint: string, headers: HeadersInit = {}): Promise<T> {
+    return this.request<T>(endpoint, { method: 'GET', headers, keepalive: true });
+  }
+
+  /**
+   * Performs a POST request to the given API endpoint.
+   *
+   * @param endpoint - Path relative to the base URL.
+   * @param body - Request body (typically a form-encoded string).
+   * @param headers - Optional additional or override headers.
+   * @returns The parsed JSON response body.
+   * @throws {FetchError} On non-2xx responses.
+   */
+  public async post<T>(endpoint: string, body: any, headers: HeadersInit = {}): Promise<T> {
+    return this.request<T>(endpoint, { method: 'POST', headers, body, keepalive: true });
   }
 }

--- a/src/wristband-service.ts
+++ b/src/wristband-service.ts
@@ -1,13 +1,8 @@
-import { AxiosError, AxiosRequestConfig } from 'axios';
-import { WristbandApiClient } from './wristband-api-client';
-import { JSON_MEDIA_TYPE } from './utils/constants';
+import { FetchError, InvalidGrantError } from './error';
 import { SdkConfiguration, UserInfo, WristbandTokenResponse, WristbandUserinfoResponse } from './types';
-import { InvalidGrantError } from './error';
-
-const SDK_CONFIGS_AXIOS_REQUEST_CONFIG: AxiosRequestConfig = {
-  auth: undefined,
-  headers: { 'Content-Type': JSON_MEDIA_TYPE, Accept: JSON_MEDIA_TYPE },
-};
+import { encodeBase64 } from './utils';
+import { FORM_URLENCODED_MEDIA_TYPE, JSON_MEDIA_TYPE } from './utils/constants';
+import { WristbandApiClient } from './wristband-api-client';
 
 /**
  * Service class for making REST API calls to the Wristband platform.
@@ -20,9 +15,8 @@ const SDK_CONFIGS_AXIOS_REQUEST_CONFIG: AxiosRequestConfig = {
  */
 export class WristbandService {
   private wristbandApiClient: WristbandApiClient;
+  private basicAuthHeaders: HeadersInit;
   private clientId: string;
-  private clientSecret: string;
-  private basicAuthConfig: AxiosRequestConfig;
 
   constructor(wristbandApplicationVanityDomain: string, clientId: string, clientSecret: string) {
     if (!wristbandApplicationVanityDomain || !wristbandApplicationVanityDomain.trim()) {
@@ -39,9 +33,10 @@ export class WristbandService {
 
     this.wristbandApiClient = new WristbandApiClient(wristbandApplicationVanityDomain);
     this.clientId = clientId;
-    this.clientSecret = clientSecret;
-    this.basicAuthConfig = {
-      auth: { username: this.clientId, password: this.clientSecret },
+    this.basicAuthHeaders = {
+      'Content-Type': FORM_URLENCODED_MEDIA_TYPE,
+      Accept: JSON_MEDIA_TYPE,
+      Authorization: `Basic ${encodeBase64(`${clientId}:${clientSecret}`)}`,
     };
   }
 
@@ -55,11 +50,10 @@ export class WristbandService {
    * @throws {Error} When the API request fails
    */
   async getSdkConfiguration(): Promise<SdkConfiguration> {
-    const response = await this.wristbandApiClient.axiosInstance.get(
-      `/clients/${this.clientId}/sdk-configuration`,
-      SDK_CONFIGS_AXIOS_REQUEST_CONFIG
-    );
-    return response.data;
+    return this.wristbandApiClient.get<SdkConfiguration>(`/clients/${this.clientId}/sdk-configuration`, {
+      'Content-Type': JSON_MEDIA_TYPE,
+      Accept: JSON_MEDIA_TYPE,
+    });
   }
 
   /**
@@ -88,20 +82,21 @@ export class WristbandService {
       throw new Error('Code verifier is required');
     }
 
+    const authData: string = [
+      'grant_type=authorization_code',
+      `code=${code}`,
+      `redirect_uri=${encodeURIComponent(redirectUri)}`,
+      `code_verifier=${encodeURIComponent(codeVerifier)}`,
+    ].join('&');
+
     try {
-      const formParams: string = `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&code_verifier=${codeVerifier}`;
-      const tokenResponse = await this.wristbandApiClient.axiosInstance.post(
+      return await this.wristbandApiClient.post<WristbandTokenResponse>(
         '/oauth2/token',
-        formParams,
-        this.basicAuthConfig
+        authData,
+        this.basicAuthHeaders
       );
-
-      // Validate response data is a valid WristbandTokenResponse
-      WristbandService.validateTokenResponse(tokenResponse.data);
-
-      return tokenResponse.data;
-    } catch (error: unknown) {
-      if (WristbandService.isAxiosError(error) && WristbandService.hasInvalidGrantError(error)) {
+    } catch (error) {
+      if (WristbandService.hasInvalidGrantError(error)) {
         throw new InvalidGrantError(WristbandService.getErrorDescription(error) || 'Invalid grant');
       }
       throw error;
@@ -125,20 +120,14 @@ export class WristbandService {
       throw new Error('Access token is required');
     }
 
-    const bearerTokenConfig = {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': JSON_MEDIA_TYPE,
-        Accept: JSON_MEDIA_TYPE,
-      },
-    };
+    const userinfo = await this.wristbandApiClient.get('/oauth2/userinfo', {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': JSON_MEDIA_TYPE,
+      Accept: JSON_MEDIA_TYPE,
+    });
 
-    const response = await this.wristbandApiClient.axiosInstance.get('/oauth2/userinfo', bearerTokenConfig);
-
-    // Validate response data is a valid UserInfo object
-    WristbandService.validateUserinfoResponse(response.data);
-
-    return WristbandService.mapUserinfoClaims(response.data);
+    WristbandService.validateUserinfoResponse(userinfo);
+    return WristbandService.mapUserinfoClaims(userinfo);
   }
 
   /**
@@ -157,20 +146,16 @@ export class WristbandService {
       throw new Error('Refresh token is required');
     }
 
+    const authData: string = `grant_type=refresh_token&refresh_token=${refreshToken}`;
+
     try {
-      const formParams: string = `grant_type=refresh_token&refresh_token=${refreshToken}`;
-      const tokenResponse = await this.wristbandApiClient.axiosInstance.post(
+      return await this.wristbandApiClient.post<WristbandTokenResponse>(
         '/oauth2/token',
-        formParams,
-        this.basicAuthConfig
+        authData,
+        this.basicAuthHeaders
       );
-
-      // Validate response data is a valid WristbandTokenResponse
-      WristbandService.validateTokenResponse(tokenResponse.data);
-
-      return tokenResponse.data;
-    } catch (error: unknown) {
-      if (WristbandService.isAxiosError(error) && WristbandService.hasInvalidGrantError(error)) {
+    } catch (error) {
+      if (WristbandService.hasInvalidGrantError(error)) {
         throw new InvalidGrantError(WristbandService.getErrorDescription(error) || 'Invalid refresh token');
       }
       throw error;
@@ -193,7 +178,7 @@ export class WristbandService {
       throw new Error('Refresh token is required');
     }
 
-    await this.wristbandApiClient.axiosInstance.post('/oauth2/revoke', `token=${refreshToken}`, this.basicAuthConfig);
+    await this.wristbandApiClient.post<void>('/oauth2/revoke', `token=${refreshToken}`, this.basicAuthHeaders);
   }
 
   /// /////////////////////////////////
@@ -201,71 +186,37 @@ export class WristbandService {
   /// /////////////////////////////////
 
   /**
-   * Type guard to check if an error is an Axios error.
+   * Checks if an error is a FetchError containing an invalid_grant error code.
    *
    * @param error - The error to check
-   * @returns True if the error is an AxiosError
+   * @returns True if the error is a FetchError with an invalid_grant body
    *
    * @internal
    */
-  private static isAxiosError(error: unknown): error is AxiosError {
-    return !!error && typeof error === 'object' && 'isAxiosError' in error;
+  private static hasInvalidGrantError(error: unknown): boolean {
+    if (error instanceof FetchError) {
+      const data = error.body;
+      return data && typeof data === 'object' && 'error' in data && (data as any).error === 'invalid_grant';
+    }
+    return false;
   }
 
   /**
-   * Checks if an Axios error response contains an invalid_grant error.
+   * Extracts the error_description field from a FetchError response body.
    *
-   * @param error - The Axios error to check
-   * @returns True if the error response has error code 'invalid_grant'
-   *
-   * @internal
-   */
-  private static hasInvalidGrantError(error: AxiosError): boolean {
-    return (
-      !!error.response?.data &&
-      typeof error.response.data === 'object' &&
-      'error' in error.response.data &&
-      error.response.data.error === 'invalid_grant'
-    );
-  }
-
-  /**
-   * Extracts the error_description field from an Axios error response.
-   *
-   * @param error - The Axios error
+   * @param error - The error to inspect
    * @returns The error description string, or undefined if not present
    *
    * @internal
    */
-  private static getErrorDescription(error: AxiosError): string | undefined {
-    if (error.response?.data && typeof error.response.data === 'object' && 'error_description' in error.response.data) {
-      return error.response.data.error_description as string;
+  private static getErrorDescription(error: unknown): string | undefined {
+    if (error instanceof FetchError) {
+      const data = error.body;
+      if (data && typeof data === 'object' && 'error_description' in data) {
+        return (data as any).error_description as string;
+      }
     }
     return undefined;
-  }
-
-  /**
-   * Validates that a token response contains required fields.
-   *
-   * Ensures the response has access_token and expires_in fields with correct types.
-   *
-   * @param data - The response data to validate
-   * @throws {Error} When response is invalid or missing required fields
-   *
-   * @internal
-   */
-  private static validateTokenResponse(data: any): asserts data is WristbandTokenResponse {
-    if (!data || typeof data !== 'object') {
-      throw new Error('Invalid token response');
-    }
-
-    if (!('access_token' in data) || typeof data.access_token !== 'string') {
-      throw new Error('Invalid token response: missing access_token');
-    }
-
-    if (!('expires_in' in data) || typeof data.expires_in !== 'number') {
-      throw new Error('Invalid token response: missing expires_in');
-    }
   }
 
   /**
@@ -276,16 +227,15 @@ export class WristbandService {
    * app_id (applicationId), and idp_name (identityProviderName).
    *
    * @param data - The raw response data from the userinfo endpoint
-   * @throws {Error} When response is not an object or missing required claims
+   * @throws {TypeError} When response is not an object or missing required claims
    *
    * @internal
    */
   private static validateUserinfoResponse(data: any): asserts data is WristbandUserinfoResponse {
-    if (!data || typeof data !== 'object') {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
       throw new TypeError('Invalid userinfo response: expected object');
     }
 
-    // Validate required fields that are always present
     if (!data.sub || typeof data.sub !== 'string') {
       throw new TypeError('Invalid userinfo response: missing sub claim');
     }
@@ -307,7 +257,6 @@ export class WristbandService {
    * @param userinfo - Raw userinfo claims from Wristband auth SDK
    * @returns Structured UserInfo object from Wristband session SDK
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static mapUserinfoClaims(userinfo: WristbandUserinfoResponse): UserInfo {
     return {
       // Always present

--- a/test/callback/callback.test.ts
+++ b/test/callback/callback.test.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import httpMocks from 'node-mocks-http';
 
 import { createWristbandAuth, WristbandAuth } from '../../src/index';
@@ -10,6 +9,22 @@ const CLIENT_ID = 'clientId';
 const CLIENT_SECRET = 'clientSecret';
 const LOGIN_STATE_COOKIE_SECRET = '7ffdbecc-ab7d-4134-9307-2dfcc52f7475';
 
+function mockFetchCallbackEndpoints(domain: string, mockTokens: unknown, mockUserinfo: unknown) {
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    const body = url.includes('/oauth2/token') ? mockTokens : mockUserinfo;
+    return Promise.resolve({
+      status: 200,
+      ok: true,
+      headers: {
+        get: () => {
+          return 'application/json';
+        },
+      },
+      text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+    });
+  });
+}
+
 describe('Multi Tenant Callback', () => {
   let wristbandAuth: WristbandAuth;
   let parseTenantFromRootDomain: string;
@@ -18,12 +33,14 @@ describe('Multi Tenant Callback', () => {
   let wristbandApplicationVanityDomain: string;
 
   beforeEach(() => {
-    nock.cleanAll();
-
     parseTenantFromRootDomain = 'localhost:6001';
     loginUrl = `https://${parseTenantFromRootDomain}/api/auth/login`;
     redirectUri = `https://${parseTenantFromRootDomain}/api/auth/callback`;
     wristbandApplicationVanityDomain = 'invotasticb2b-invotastic.dev.wristband.dev';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('Callback Happy Path', () => {
@@ -37,7 +54,7 @@ describe('Multi Tenant Callback', () => {
         wristbandApplicationVanityDomain,
         autoConfigureEnabled: false,
       });
-      // Mock token data
+
       const mockTokens = {
         access_token: 'accessToken',
         expires_in: 1800,
@@ -45,14 +62,6 @@ describe('Multi Tenant Callback', () => {
         refresh_token: 'refreshToken',
         token_type: 'bearer',
       };
-      const tokenScope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .post(
-          '/api/v1/oauth2/token',
-          `grant_type=authorization_code&code=code&redirect_uri=${redirectUri}&code_verifier=codeVerifier`
-        )
-        .reply(200, mockTokens);
-      // Mock userinfo data
       const mockUserinfo = {
         sub: '5q6j4qe2cva3dm3cbdvjoxvuze',
         tnt_id: 'fr2vishnqjdvfbcijxa3a4adhe',
@@ -61,11 +70,8 @@ describe('Multi Tenant Callback', () => {
         email: 'test@wristband.dev',
         email_verified: true,
       };
-      const userinfoScope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .get('/api/v1/oauth2/userinfo')
-        .reply(200, mockUserinfo);
-      // Mock login state
+      mockFetchCallbackEndpoints(wristbandApplicationVanityDomain, mockTokens, mockUserinfo);
+
       const loginState: LoginState = {
         codeVerifier: 'codeVerifier',
         redirectUri: redirectUri,
@@ -74,7 +80,7 @@ describe('Multi Tenant Callback', () => {
         returnUrl: 'https://reddit.com',
       };
       const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-      // Mock Express objects
+
       const mockExpressReq = httpMocks.createRequest({
         query: { state: 'state', code: 'code', tenant_name: 'devs4you' },
         headers: {
@@ -82,7 +88,7 @@ describe('Multi Tenant Callback', () => {
         },
       }) as any;
       const mockExpressRes = httpMocks.createResponse() as any;
-      // Validate callback data contents
+
       const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       const { callbackData, type } = callbackResult;
       expect(type).toBe('completed');
@@ -103,18 +109,17 @@ describe('Multi Tenant Callback', () => {
         expect(callbackData.userinfo.email).toBe('test@wristband.dev');
         expect(callbackData.userinfo.emailVerified).toBe(true);
       }
-      // Validate response is not redirecting the user
+
       // eslint-disable-next-line no-underscore-dangle
       const location: string = mockExpressRes._getRedirectUrl();
       expect(location).toBeFalsy();
-      // Validate no-cache headers
+
       // eslint-disable-next-line no-underscore-dangle
       const headers = mockExpressRes._getHeaders();
       expect(Object.keys(headers)).toHaveLength(3);
       expect(headers['cache-control']).toBe('no-store');
       expect(headers['pragma']).toBe('no-cache');
 
-      // Validate login state cookie is getting cleared
       const setCookieHeader = headers['set-cookie'];
       expect(setCookieHeader).toBeTruthy();
       const setCookieValue = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
@@ -133,8 +138,7 @@ describe('Multi Tenant Callback', () => {
       expect(setCookieValue).toContain('HttpOnly');
       expect(setCookieValue).toContain('Max-Age=0');
 
-      tokenScope.done();
-      userinfoScope.done();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
     describe.each([
@@ -156,7 +160,7 @@ describe('Multi Tenant Callback', () => {
           wristbandApplicationVanityDomain,
           autoConfigureEnabled: false,
         });
-        // Mock token data
+
         const mockTokens = {
           access_token: 'accessToken',
           expires_in: 1800,
@@ -164,14 +168,6 @@ describe('Multi Tenant Callback', () => {
           refresh_token: 'refreshToken',
           token_type: 'bearer',
         };
-        const tokenScope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post(
-            '/api/v1/oauth2/token',
-            `grant_type=authorization_code&code=code&redirect_uri=${redirectUri}&code_verifier=codeVerifier`
-          )
-          .reply(200, mockTokens);
-        // Mock userinfo data
         const mockUserinfo = {
           sub: '5q6j4qe2cva3dm3cbdvjoxvuze',
           tnt_id: 'fr2vishnqjdvfbcijxa3a4adhe',
@@ -180,18 +176,15 @@ describe('Multi Tenant Callback', () => {
           email: 'test@wristband.dev',
           email_verified: true,
         };
-        const userinfoScope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .get('/api/v1/oauth2/userinfo')
-          .reply(200, mockUserinfo);
-        // Mock login state
+        mockFetchCallbackEndpoints(wristbandApplicationVanityDomain, mockTokens, mockUserinfo);
+
         const loginState: LoginState = {
           codeVerifier: 'codeVerifier',
           redirectUri: redirectUri,
           state: 'state',
         };
         const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-        // Mock Express objects
+
         const mockExpressReq = httpMocks.createRequest({
           query: { state: 'state', code: 'code' },
           headers: {
@@ -200,7 +193,7 @@ describe('Multi Tenant Callback', () => {
           },
         }) as any;
         const mockExpressRes = httpMocks.createResponse() as any;
-        // Validate callback data contents
+
         const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
         const { callbackData, type } = callbackResult;
         expect(type).toBe('completed');
@@ -210,12 +203,11 @@ describe('Multi Tenant Callback', () => {
           expect(callbackData.customState).toBeFalsy();
           expect(callbackData.returnUrl).toBeFalsy();
         }
-        // Validate response is not redirecting the user
+
         // eslint-disable-next-line no-underscore-dangle
         const location: string = mockExpressRes._getRedirectUrl();
         expect(location).toBeFalsy();
-        tokenScope.done();
-        userinfoScope.done();
+        expect(global.fetch).toHaveBeenCalledTimes(2);
       });
     });
 
@@ -239,7 +231,7 @@ describe('Multi Tenant Callback', () => {
           wristbandApplicationVanityDomain,
           autoConfigureEnabled: false,
         });
-        // Mock token data
+
         const mockTokens = {
           access_token: 'accessToken',
           expires_in: 1800,
@@ -247,14 +239,6 @@ describe('Multi Tenant Callback', () => {
           refresh_token: 'refreshToken',
           token_type: 'bearer',
         };
-        const tokenScope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post(
-            '/api/v1/oauth2/token',
-            `grant_type=authorization_code&code=code&redirect_uri=${redirectUri}&code_verifier=codeVerifier`
-          )
-          .reply(200, mockTokens);
-        // Mock userinfo data
         const mockUserinfo = {
           sub: '5q6j4qe2cva3dm3cbdvjoxvuze',
           tnt_id: 'fr2vishnqjdvfbcijxa3a4adhe',
@@ -263,18 +247,15 @@ describe('Multi Tenant Callback', () => {
           email: 'test@wristband.dev',
           email_verified: true,
         };
-        const userinfoScope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .get('/api/v1/oauth2/userinfo')
-          .reply(200, mockUserinfo);
-        // Mock login state
+        mockFetchCallbackEndpoints(wristbandApplicationVanityDomain, mockTokens, mockUserinfo);
+
         const loginState: LoginState = {
           codeVerifier: 'codeVerifier',
           redirectUri: redirectUri,
           state: 'state',
         };
         const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-        // Mock Express objects
+
         const mockExpressReq = httpMocks.createRequest({
           query: { state: 'state', code: 'code' },
           headers: {
@@ -283,7 +264,7 @@ describe('Multi Tenant Callback', () => {
           },
         }) as any;
         const mockExpressRes = httpMocks.createResponse() as any;
-        // Validate callback data contents
+
         const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
         const { callbackData, type } = callbackResult;
         expect(type).toBe('completed');
@@ -293,12 +274,11 @@ describe('Multi Tenant Callback', () => {
           expect(callbackData.customState).toBeFalsy();
           expect(callbackData.returnUrl).toBeFalsy();
         }
-        // Validate response is not redirecting the user
+
         // eslint-disable-next-line no-underscore-dangle
         const location: string = mockExpressRes._getRedirectUrl();
         expect(location).toBeFalsy();
-        tokenScope.done();
-        userinfoScope.done();
+        expect(global.fetch).toHaveBeenCalledTimes(2);
       });
     });
   });
@@ -318,13 +298,13 @@ describe('Multi Tenant Callback', () => {
         wristbandApplicationVanityDomain,
         autoConfigureEnabled: false,
       });
-      // Mock Express objects
+
       const mockExpressReq = httpMocks.createRequest({
         headers: { host: `${parseTenantFromRootDomain}` },
         query: { state: 'state', code: 'code', tenant_name: 'devs4you' },
       }) as any;
       const mockExpressRes = httpMocks.createResponse() as any;
-      // login state cookie is missing, which should redirect to app-level login.
+
       const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       const { callbackData, redirectUrl, type } = callbackResult;
       expect(type).toBe('redirect_required');
@@ -351,13 +331,13 @@ describe('Multi Tenant Callback', () => {
           wristbandApplicationVanityDomain,
           autoConfigureEnabled: false,
         });
-        // Mock Express objects
+
         const mockExpressReq = httpMocks.createRequest({
           headers: { host: `devs4you.${parseTenantFromRootDomain}` },
           query: { state: 'state', code: 'code' },
         }) as any;
         const mockExpressRes = httpMocks.createResponse() as any;
-        // login state cookie is missing, which should redirect to app-level login.
+
         const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
         const { callbackData, redirectUrl, type } = callbackResult;
         expect(type).toBe('redirect_required');
@@ -380,10 +360,10 @@ describe('Multi Tenant Callback', () => {
         wristbandApplicationVanityDomain,
         autoConfigureEnabled: false,
       });
-      // Mock login state
+
       const loginState: LoginState = { codeVerifier: 'codeVerifier', redirectUri: redirectUri, state: 'state' };
       const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-      // Mock Express objects
+
       const mockExpressReq = httpMocks.createRequest({
         query: {
           state: 'state',
@@ -397,6 +377,7 @@ describe('Multi Tenant Callback', () => {
         },
       }) as any;
       const mockExpressRes = httpMocks.createResponse() as any;
+
       const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       const { callbackData, redirectUrl, type } = callbackResult;
       expect(type).toBe('redirect_required');
@@ -423,10 +404,10 @@ describe('Multi Tenant Callback', () => {
           wristbandApplicationVanityDomain,
           autoConfigureEnabled: false,
         });
-        // Mock login state
+
         const loginState: LoginState = { codeVerifier: 'codeVerifier', redirectUri: redirectUri, state: 'state' };
         const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-        // Mock Express objects
+
         const mockExpressReq = httpMocks.createRequest({
           query: { state: 'state', code: 'code', error: 'login_required', error_description: 'Login required' },
           headers: {
@@ -435,6 +416,7 @@ describe('Multi Tenant Callback', () => {
           },
         }) as any;
         const mockExpressRes = httpMocks.createResponse() as any;
+
         const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
         const { callbackData, redirectUrl, type } = callbackResult;
         expect(type).toBe('redirect_required');
@@ -457,10 +439,10 @@ describe('Multi Tenant Callback', () => {
         wristbandApplicationVanityDomain,
         autoConfigureEnabled: false,
       });
-      // Mock login state
+
       const loginState: LoginState = { codeVerifier: 'codeVerifier', redirectUri: redirectUri, state: 'bad_state' };
       const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-      // Mock Express objects
+
       const mockExpressReq = httpMocks.createRequest({
         query: { state: 'state', code: 'code', tenant_name: 'devs4you' },
         headers: {
@@ -468,6 +450,7 @@ describe('Multi Tenant Callback', () => {
         },
       }) as any;
       const mockExpressRes = httpMocks.createResponse() as any;
+
       const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       const { callbackData, redirectUrl, type } = callbackResult;
       expect(type).toBe('redirect_required');
@@ -494,10 +477,10 @@ describe('Multi Tenant Callback', () => {
           wristbandApplicationVanityDomain,
           autoConfigureEnabled: false,
         });
-        // Mock login state
+
         const loginState: LoginState = { codeVerifier: 'codeVerifier', redirectUri: redirectUri, state: 'bad_state' };
         const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
-        // Mock Express objects
+
         const mockExpressReq = httpMocks.createRequest({
           query: { state: 'state', code: 'code' },
           headers: {
@@ -506,6 +489,7 @@ describe('Multi Tenant Callback', () => {
           },
         }) as any;
         const mockExpressRes = httpMocks.createResponse() as any;
+
         const callbackResult: CallbackResult = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
         const { callbackData, redirectUrl, type } = callbackResult;
         expect(type).toBe('redirect_required');

--- a/test/callback/error.test.ts
+++ b/test/callback/error.test.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import httpMocks from 'node-mocks-http';
 
 import { LoginState } from '../../src/types';
@@ -13,6 +12,19 @@ const LOGIN_URL = 'http://localhost:6001/api/auth/login';
 const REDIRECT_URI = 'http://localhost:6001/api/auth/callback';
 const WRISTBAND_APPLICATION_DOMAIN = 'invotasticb2c-invotastic.dev.wristband.dev';
 
+function mockFetchToken(status: number, body: unknown) {
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return 'application/json';
+      },
+    },
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  });
+}
+
 describe('Callback Errors', () => {
   let wristbandAuth: WristbandAuth;
 
@@ -26,17 +38,18 @@ describe('Callback Errors', () => {
       wristbandApplicationVanityDomain: WRISTBAND_APPLICATION_DOMAIN,
       autoConfigureEnabled: false,
     });
-    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test('Invalid state query param', async () => {
-    // Mock Express objects
     let mockExpressReq = httpMocks.createRequest({
       query: { code: 'code', tenant_name: 'devs4you' },
     }) as any;
     let mockExpressRes = httpMocks.createResponse() as any;
 
-    // Missing state query parameter should throw an error
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -50,7 +63,6 @@ describe('Callback Errors', () => {
     }) as unknown as Request;
     mockExpressRes = httpMocks.createResponse();
 
-    // Multiple state query parameters should throw an error
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -61,7 +73,6 @@ describe('Callback Errors', () => {
   });
 
   test('Invalid code query param', async () => {
-    // Mock login state
     const loginState: LoginState = {
       codeVerifier: 'codeVerifier',
       redirectUri: REDIRECT_URI,
@@ -69,7 +80,6 @@ describe('Callback Errors', () => {
     };
     const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
 
-    // Mock Express objects
     let mockExpressReq = httpMocks.createRequest({
       query: { state: 'state', tenant_name: 'devs4you' },
       headers: {
@@ -78,7 +88,6 @@ describe('Callback Errors', () => {
     }) as any;
     let mockExpressRes = httpMocks.createResponse() as any;
 
-    // Missing code query parameter should throw an error for happy path scenarios.
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -94,7 +103,7 @@ describe('Callback Errors', () => {
       },
     }) as unknown as Request;
     mockExpressRes = httpMocks.createResponse() as unknown as Response;
-    // Multiple code query parameters should throw an error.
+
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -105,7 +114,6 @@ describe('Callback Errors', () => {
   });
 
   test('Invalid error query param', async () => {
-    // Mock Express objects
     const mockExpressReq = httpMocks.createRequest({
       query: { state: 'state', error: ['a', 'b'] },
       headers: {
@@ -114,7 +122,6 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    // Multiple error query parameters should throw an error.
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -125,7 +132,6 @@ describe('Callback Errors', () => {
   });
 
   test('Invalid error_description query param', async () => {
-    // Mock Express objects
     const mockExpressReq = httpMocks.createRequest({
       query: { state: 'state', error_description: ['a', 'b'] },
       headers: {
@@ -134,7 +140,6 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    // Multiple error_description query parameters should throw an error.
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -145,7 +150,6 @@ describe('Callback Errors', () => {
   });
 
   test('Invalid tenant_name query param', async () => {
-    // Mock Express objects
     const mockExpressReq = httpMocks.createRequest({
       query: { state: 'state', tenant_name: ['a', 'b'] },
       headers: {
@@ -154,7 +158,6 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    // Multiple tenant_name query parameters should throw an error.
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -165,7 +168,6 @@ describe('Callback Errors', () => {
   });
 
   test('Invalid tenant_custom_domain query param', async () => {
-    // Mock Express objects
     const mockExpressReq = httpMocks.createRequest({
       query: { state: 'state', tenant_custom_domain: ['a', 'b'] },
       headers: {
@@ -174,7 +176,6 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    // Multiple error query parameters should throw an error.
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -187,7 +188,6 @@ describe('Callback Errors', () => {
   });
 
   test('Error query parameter throws WristbandError', async () => {
-    // Mock login state
     const loginState: LoginState = {
       codeVerifier: 'codeVerifier',
       redirectUri: REDIRECT_URI,
@@ -195,7 +195,6 @@ describe('Callback Errors', () => {
     };
     const encryptedLoginState: string = await encryptLoginState(loginState, LOGIN_STATE_COOKIE_SECRET);
 
-    // Mock Express objects
     const mockExpressReq = httpMocks.createRequest({
       query: { state: 'state', tenant_name: 'devs4you', error: 'BAD', error_description: 'Really bad' },
       headers: {
@@ -204,7 +203,6 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    // Only some errors are handled automatically by the SDK. All others will throw a WristbandError.
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
       fail('Error expected to be thrown.');
@@ -223,7 +221,6 @@ describe('Callback Errors', () => {
         code: 'testcode',
         tenant_name: 'tenant1',
       },
-      // No cookie header
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
@@ -315,10 +312,7 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`).post('/api/v1/oauth2/token').reply(400, {
-      error: 'invalid_grant',
-      error_description: 'Token exchange failed',
-    });
+    mockFetchToken(400, { error: 'invalid_grant', error_description: 'Token exchange failed' });
 
     const result = await wristbandAuth.callback(mockExpressReq, mockExpressRes);
 
@@ -349,10 +343,7 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`).post('/api/v1/oauth2/token').reply(500, {
-      error: 'server_error',
-      error_description: 'Internal server error',
-    });
+    mockFetchToken(500, { error: 'server_error', error_description: 'Internal server error' });
 
     try {
       await wristbandAuth.callback(mockExpressReq, mockExpressRes);
@@ -402,10 +393,7 @@ describe('Callback Errors', () => {
     }) as any;
     const mockExpressRes = httpMocks.createResponse() as any;
 
-    nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`).post('/api/v1/oauth2/token').reply(400, {
-      error: 'invalid_grant',
-      error_description: 'Token exchange failed',
-    });
+    mockFetchToken(400, { error: 'invalid_grant', error_description: 'Token exchange failed' });
 
     const result = await tenantSubdomainAuth.callback(mockExpressReq, mockExpressRes);
 

--- a/test/config-resolver.test.ts
+++ b/test/config-resolver.test.ts
@@ -561,10 +561,18 @@ describe('ConfigResolver', () => {
       const invalidSdkConfig = { loginUrl: 'https://test.example.com/auth/login' } as SdkConfiguration;
       initWristbandServiceMock(invalidSdkConfig);
       resolver = new ConfigResolver(validAuthConfig);
-
       await expect(resolver.getRedirectUri()).rejects.toThrow(
-        'SDK configuration response missing required field: redirectUri'
+        'The [redirectUri] could not be resolved. Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.'
       );
+    });
+
+    it('should not throw when redirectUri missing from auto-config but manually provided', async () => {
+      const invalidSdkConfig = { loginUrl: 'https://test.example.com/auth/login' } as SdkConfiguration;
+      initWristbandServiceMock(invalidSdkConfig);
+      const config = { ...validAuthConfig, redirectUri: 'https://manual.com/callback' };
+      resolver = new ConfigResolver(config);
+
+      await expect(resolver.getRedirectUri()).resolves.toBe('https://manual.com/callback');
     });
   });
 
@@ -687,7 +695,19 @@ describe('ConfigResolver', () => {
       const invalidSdkConfig = { loginUrl: 'https://test.com/login' } as SdkConfiguration;
       expect(() => {
         return resolver['validateAllDynamicConfigs'](invalidSdkConfig);
-      }).toThrow('SDK configuration response missing required field: redirectUri');
+      }).toThrow(
+        'The [redirectUri] could not be resolved. Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.'
+      );
+    });
+
+    it('should not throw when redirectUri missing from SDK config but manually provided', () => {
+      const manualConfig = { ...validAuthConfig, redirectUri: 'https://manual.com/callback' };
+      resolver = new ConfigResolver(manualConfig);
+
+      const invalidSdkConfig = { loginUrl: 'https://test.com/login' } as SdkConfiguration;
+      expect(() => {
+        return resolver['validateAllDynamicConfigs'](invalidSdkConfig);
+      }).not.toThrow();
     });
 
     it(`should validate resolved config with parseTenantFromRootDomain requires ${placeholderName}`, () => {

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,4 +1,4 @@
-import { WristbandError, InvalidGrantError } from '../src/error';
+import { WristbandError, InvalidGrantError, FetchError } from '../src/error';
 
 describe('Error Classes', () => {
   describe('WristbandError', () => {
@@ -139,6 +139,108 @@ describe('Error Classes', () => {
     test('Error has correct name property', () => {
       const error = new InvalidGrantError('Test');
       expect(error.name).toBe('WristbandError'); // Inherits from WristbandError
+    });
+  });
+
+  describe('FetchError', () => {
+    test('Creates error with response and body', () => {
+      const mockResponse = new Response(null, { status: 400 });
+      const body = { error: 'invalid_grant', error_description: 'Invalid grant' };
+      const error = new FetchError(mockResponse, body);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(FetchError);
+      expect(error.name).toBe('FetchError');
+      expect(error.message).toBe('Fetch Error');
+      expect(error.response).toBe(mockResponse);
+      expect(error.body).toBe(body);
+    });
+
+    test('Creates error with undefined body', () => {
+      const mockResponse = new Response(null, { status: 204 });
+      const error = new FetchError(mockResponse, undefined);
+
+      expect(error).toBeInstanceOf(FetchError);
+      expect(error.response).toBe(mockResponse);
+      expect(error.body).toBeUndefined();
+    });
+
+    test('Creates error with null body', () => {
+      const mockResponse = new Response(null, { status: 500 });
+      const error = new FetchError(mockResponse, null);
+
+      expect(error).toBeInstanceOf(FetchError);
+      expect(error.response).toBe(mockResponse);
+      expect(error.body).toBeNull();
+    });
+
+    test('Creates error with string body', () => {
+      const mockResponse = new Response(null, { status: 503 });
+      const error = new FetchError(mockResponse, 'Service Unavailable');
+
+      expect(error).toBeInstanceOf(FetchError);
+      expect(error.body).toBe('Service Unavailable');
+    });
+
+    test('Response and body properties are readonly', () => {
+      const mockResponse = new Response(null, { status: 400 });
+      const error = new FetchError(mockResponse, { error: 'bad_request' });
+
+      // TypeScript readonly enforced at compile time; verify values are stable at runtime
+      expect(error.response).toBe(mockResponse);
+      expect(error.body).toEqual({ error: 'bad_request' });
+    });
+
+    test('Works with generic response type', () => {
+      interface MockResponse {
+        status: number;
+        ok: boolean;
+      }
+      const mockResponse: MockResponse = { status: 401, ok: false };
+      const error = new FetchError<MockResponse>(mockResponse, { error: 'unauthorized' });
+
+      expect(error.response?.status).toBe(401);
+      expect(error.response?.ok).toBe(false);
+    });
+
+    test('Error can be thrown and caught', () => {
+      const mockResponse = new Response(null, { status: 400 });
+      expect(() => {
+        throw new FetchError(mockResponse, { error: 'bad_request' });
+      }).toThrow(FetchError);
+    });
+
+    test('Error has correct prototype chain', () => {
+      const mockResponse = new Response(null, { status: 400 });
+      const error = new FetchError(mockResponse, null);
+
+      expect(error instanceof FetchError).toBe(true);
+      expect(error instanceof Error).toBe(true);
+    });
+
+    test('instanceof check works for downstream error handling', () => {
+      const mockResponse = new Response(null, { status: 400 });
+      const fetchError = new FetchError(mockResponse, { error: 'invalid_grant' });
+      const regularError = new Error('regular error');
+
+      expect(fetchError instanceof FetchError).toBe(true);
+      expect(regularError instanceof FetchError).toBe(false);
+    });
+
+    test('Body with invalid_grant error is accessible', () => {
+      const mockResponse = new Response(null, { status: 400 });
+      const body = { error: 'invalid_grant', error_description: 'The authorization code has expired' };
+      const error = new FetchError(mockResponse, body);
+
+      expect(error.body.error).toBe('invalid_grant');
+      expect(error.body.error_description).toBe('The authorization code has expired');
+    });
+
+    test('Response status is accessible via response property', () => {
+      const mockResponse = new Response(null, { status: 401 });
+      const error = new FetchError(mockResponse, { error: 'unauthorized' });
+
+      expect(error.response?.status).toBe(401);
     });
   });
 });

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import { createWristbandAuth, discoverWristbandAuth } from '../src/factory';
 import { WristbandError } from '../src/error';
 import { TENANT_DOMAIN_PLACEHOLDER, TENANT_NAME_PLACEHOLDER } from '../src/utils/constants';
@@ -10,14 +9,32 @@ const LOGIN_URL = 'http://localhost:6001/api/auth/login';
 const REDIRECT_URI = 'http://localhost:6001/api/auth/callback';
 const ROOT_DOMAIN = 'business.invotastic.com';
 const WRISTBAND_APPLICATION_DOMAIN = 'invotasticb2b-invotastic.dev.wristband.dev';
+const SDK_CONFIG_ENDPOINT = `https://${WRISTBAND_APPLICATION_DOMAIN}/api/v1/clients/${CLIENT_ID}/sdk-configuration`;
 
-// Helper functions to create URLs with placeholders
 const getLoginUrlWithPlaceholder = (placeholder: string) => {
   return `http://${placeholder}.business.invotastic.com/api/auth/login`;
 };
 const getRedirectUriWithPlaceholder = (placeholder: string) => {
   return `http://${placeholder}.business.invotastic.com/api/auth/callback`;
 };
+
+function mockFetchSdkConfig(responses: { status: number; body: unknown }[]) {
+  let callCount = 0;
+  global.fetch = jest.fn().mockImplementation(() => {
+    const response = responses[Math.min(callCount, responses.length - 1)];
+    callCount += 1;
+    return Promise.resolve({
+      status: response.status,
+      ok: response.status >= 200 && response.status < 300,
+      headers: {
+        get: () => {
+          return 'application/json';
+        },
+      },
+      text: jest.fn().mockResolvedValue(JSON.stringify(response.body)),
+    });
+  });
+}
 
 describe('createWristbandAuth Instantiation Errors', () => {
   test('Empty clientId', async () => {
@@ -187,8 +204,8 @@ describe('createWristbandAuth Instantiation Errors', () => {
 });
 
 describe('discoverWristbandAuth', () => {
-  beforeEach(() => {
-    nock.cleanAll();
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test('error when autoConfigureEnabled set to false', async () => {
@@ -213,10 +230,7 @@ describe('discoverWristbandAuth', () => {
       loginUrlTenantDomainSuffix: null,
       redirectUri: REDIRECT_URI,
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-      .reply(200, mockSdkConfig);
+    mockFetchSdkConfig([{ status: 200, body: mockSdkConfig }]);
 
     const wristbandAuth = await discoverWristbandAuth({
       clientId: CLIENT_ID,
@@ -229,14 +243,17 @@ describe('discoverWristbandAuth', () => {
     expect(wristbandAuth.callback).toBeDefined();
     expect(wristbandAuth.logout).toBeDefined();
     expect(wristbandAuth.refreshTokenIfExpired).toBeDefined();
-
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(SDK_CONFIG_ENDPOINT, expect.any(Object));
   });
 
   test('Handles SDK configuration fetch failure', async () => {
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-      .reply(500, { error: 'Internal Server Error' });
+    // 3 attempts all fail — exhausts MAX_FETCH_ATTEMPTS
+    mockFetchSdkConfig([
+      { status: 500, body: { error: 'Internal Server Error' } },
+      { status: 500, body: { error: 'Internal Server Error' } },
+      { status: 500, body: { error: 'Internal Server Error' } },
+    ]);
 
     await expect(
       discoverWristbandAuth({
@@ -247,7 +264,7 @@ describe('discoverWristbandAuth', () => {
       })
     ).rejects.toThrow();
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
   test('Discovery fails with partial manual config override', async () => {
@@ -258,10 +275,7 @@ describe('discoverWristbandAuth', () => {
       loginUrlTenantDomainSuffix: 'sdk.domain.com',
       redirectUri: 'https://sdk-redirect.com',
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-      .reply(200, mockSdkConfig);
+    mockFetchSdkConfig([{ status: 200, body: mockSdkConfig }]);
 
     await expect(
       discoverWristbandAuth({
@@ -274,13 +288,11 @@ describe('discoverWristbandAuth', () => {
       })
     ).rejects.toThrow();
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Discovery with invalid SDK configuration response', async () => {
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-      .reply(200, { invalid: 'response' }); // Missing required fields
+    mockFetchSdkConfig([{ status: 200, body: { invalid: 'response' } }]);
 
     await expect(
       discoverWristbandAuth({
@@ -290,6 +302,6 @@ describe('discoverWristbandAuth', () => {
       })
     ).rejects.toThrow();
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/login/error.test.ts
+++ b/test/login/error.test.ts
@@ -85,6 +85,21 @@ describe('Login Errors', () => {
     }
   });
 
+  test('With multiple idp_hint query params throws TypeError', async () => {
+    const mockExpressReq = httpMocks.createRequest({
+      query: { tenant_name: 'test', idp_hint: ['hint1', 'hint2'] },
+    }) as any;
+    const mockExpressRes = httpMocks.createResponse() as any;
+
+    try {
+      mockExpressRes.redirect(await wristbandAuth.login(mockExpressReq, mockExpressRes));
+      fail('Error expected to be thrown.');
+    } catch (error: any) {
+      expect(error instanceof TypeError).toBe(true);
+      expect(error.message).toBe('More than one [idp_hint] query parameter was encountered');
+    }
+  });
+
   test('Way too large customState', async () => {
     const mockExpressReq = httpMocks.createRequest({
       query: { tenant_name: 'test' },

--- a/test/login/login.test.ts
+++ b/test/login/login.test.ts
@@ -497,6 +497,42 @@ describe('Multi Tenant Login', () => {
       expect(loginState.returnUrl).toBe(`https://devs4you.${parseTenantFromRootDomain}/settings`);
     });
 
+    test('With idp_hint query param', async () => {
+      parseTenantFromRootDomain = 'business.invotastic.com';
+      wristbandApplicationVanityDomain = 'auth.invotastic.com';
+      loginUrl = `https://{tenant_name}.${parseTenantFromRootDomain}/api/auth/login`;
+      redirectUri = `https://{tenant_name}.${parseTenantFromRootDomain}/api/auth/callback`;
+
+      wristbandAuth = createWristbandAuth({
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+        loginStateSecret: LOGIN_STATE_COOKIE_SECRET,
+        loginUrl,
+        redirectUri,
+        parseTenantFromRootDomain,
+        isApplicationCustomDomainActive: true,
+        wristbandApplicationVanityDomain,
+        autoConfigureEnabled: false,
+      });
+
+      const mockExpressReq = httpMocks.createRequest({
+        headers: { host: `devs4you.${parseTenantFromRootDomain}` },
+        query: { idp_hint: 'google' },
+      }) as any;
+      const mockExpressRes = httpMocks.createResponse() as any;
+
+      mockExpressRes.redirect(await wristbandAuth.login(mockExpressReq, mockExpressRes));
+
+      const { statusCode } = mockExpressRes;
+      expect(statusCode).toEqual(302);
+      const location: string = mockExpressRes._getRedirectUrl();
+      expect(location).toBeTruthy();
+      const locationUrl: URL = new URL(location);
+      const { searchParams } = locationUrl;
+
+      expect(searchParams.get('idp_hint')).toBe('google');
+    });
+
     test('With returnUrl in LoginConfig', async () => {
       wristbandAuth = createWristbandAuth({
         clientId: CLIENT_ID,

--- a/test/logout/error.test.ts
+++ b/test/logout/error.test.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import httpMocks from 'node-mocks-http';
 
 import { createWristbandAuth, WristbandAuth } from '../../src/index';
@@ -29,8 +28,6 @@ describe('Logout Errors', () => {
       wristbandApplicationVanityDomain,
       autoConfigureEnabled: false,
     });
-
-    nock.cleanAll();
   });
 
   test('Multiple tenant_name params', async () => {

--- a/test/logout/logout.test.ts
+++ b/test/logout/logout.test.ts
@@ -1,7 +1,5 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-underscore-dangle */
 
-import nock from 'nock';
 import httpMocks from 'node-mocks-http';
 
 import { createWristbandAuth, WristbandAuth } from '../../src/index';
@@ -9,6 +7,26 @@ import { createWristbandAuth, WristbandAuth } from '../../src/index';
 const CLIENT_ID = 'clientId';
 const CLIENT_SECRET = 'clientSecret';
 const LOGIN_STATE_COOKIE_SECRET = '7ffdbecc-ab7d-4134-9307-2dfcc52f7475';
+
+function mockFetchRevoke(status: number) {
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return 'application/json';
+      },
+    },
+    text: jest.fn().mockResolvedValue(''),
+  });
+}
+
+function expectRevokeCalled(domain: string) {
+  expect(global.fetch).toHaveBeenCalledWith(
+    `https://${domain}/api/v1/oauth2/revoke`,
+    expect.objectContaining({ method: 'POST', body: 'token=refreshToken' })
+  );
+}
 
 describe('Multi Tenant Logout', () => {
   let wristbandAuth: WristbandAuth;
@@ -22,16 +40,16 @@ describe('Multi Tenant Logout', () => {
     loginUrl = `https://${parseTenantFromRootDomain}/api/auth/login`;
     redirectUri = `https://${parseTenantFromRootDomain}/api/auth/callback`;
     wristbandApplicationVanityDomain = 'invotasticb2c-invotastic.dev.wristband.dev';
-    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('Domain Resolution Priority Tests', () => {
     describe('Priority 1: logoutConfig.tenantCustomDomain (highest priority)', () => {
       test('tenantCustomDomain config overrides everything else', async () => {
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -70,16 +88,13 @@ describe('Multi Tenant Logout', () => {
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
         expect(searchParams.get('redirect_url')).toEqual('https://example.com');
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
 
     describe('Priority 2: logoutConfig.tenantName', () => {
       test('tenantName config with default separator', async () => {
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -115,14 +130,11 @@ describe('Multi Tenant Logout', () => {
         expect(pathname).toEqual('/api/v1/logout');
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
 
       test('tenantName config with custom domain separator', async () => {
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -158,16 +170,13 @@ describe('Multi Tenant Logout', () => {
         expect(pathname).toEqual('/api/v1/logout');
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
 
     describe('Priority 3: tenant_custom_domain query parameter', () => {
       test('tenant_custom_domain query param used when no config overrides', async () => {
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -202,14 +211,11 @@ describe('Multi Tenant Logout', () => {
         expect(pathname).toEqual('/api/v1/logout');
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
 
       test('tenant_custom_domain query param with redirect URL', async () => {
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -246,7 +252,7 @@ describe('Multi Tenant Logout', () => {
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
         expect(searchParams.get('redirect_url')).toEqual('https://redirect.example.com');
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
 
@@ -260,10 +266,7 @@ describe('Multi Tenant Logout', () => {
           loginUrl = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/login`;
           redirectUri = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-          const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-            .persist()
-            .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-            .reply(200);
+          mockFetchRevoke(200);
 
           wristbandAuth = createWristbandAuth({
             clientId: CLIENT_ID,
@@ -298,7 +301,7 @@ describe('Multi Tenant Logout', () => {
           expect(pathname).toEqual('/api/v1/logout');
           expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-          scope.done();
+          expectRevokeCalled(wristbandApplicationVanityDomain);
         });
 
         test(`tenant subdomain with custom domain separator using ${placeholderName}`, async () => {
@@ -306,10 +309,7 @@ describe('Multi Tenant Logout', () => {
           loginUrl = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/login`;
           redirectUri = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-          const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-            .persist()
-            .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-            .reply(200);
+          mockFetchRevoke(200);
 
           wristbandAuth = createWristbandAuth({
             clientId: CLIENT_ID,
@@ -345,16 +345,13 @@ describe('Multi Tenant Logout', () => {
           expect(pathname).toEqual('/api/v1/logout');
           expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-          scope.done();
+          expectRevokeCalled(wristbandApplicationVanityDomain);
         });
       });
 
       describe('4b: Tenant subdomains disabled - query param', () => {
         test('tenant_name query parameter with default separator', async () => {
-          const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-            .persist()
-            .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-            .reply(200);
+          mockFetchRevoke(200);
 
           wristbandAuth = createWristbandAuth({
             clientId: CLIENT_ID,
@@ -389,14 +386,11 @@ describe('Multi Tenant Logout', () => {
           expect(pathname).toEqual('/api/v1/logout');
           expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-          scope.done();
+          expectRevokeCalled(wristbandApplicationVanityDomain);
         });
 
         test('tenant_name query parameter with custom domain separator', async () => {
-          const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-            .persist()
-            .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-            .reply(200);
+          mockFetchRevoke(200);
 
           wristbandAuth = createWristbandAuth({
             clientId: CLIENT_ID,
@@ -432,7 +426,7 @@ describe('Multi Tenant Logout', () => {
           expect(pathname).toEqual('/api/v1/logout');
           expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-          scope.done();
+          expectRevokeCalled(wristbandApplicationVanityDomain);
         });
       });
     });
@@ -530,10 +524,7 @@ describe('Multi Tenant Logout', () => {
 
   describe('Logout Happy Path', () => {
     test('Default Configuration', async () => {
-      const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-        .reply(200);
+      mockFetchRevoke(200);
 
       wristbandAuth = createWristbandAuth({
         clientId: CLIENT_ID,
@@ -578,7 +569,7 @@ describe('Multi Tenant Logout', () => {
       expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
       expect(searchParams.get('redirect_url')).toEqual('https://google.com');
 
-      scope.done();
+      expectRevokeCalled(wristbandApplicationVanityDomain);
     });
 
     describe.each([
@@ -590,10 +581,7 @@ describe('Multi Tenant Logout', () => {
         loginUrl = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/login`;
         redirectUri = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -637,7 +625,7 @@ describe('Multi Tenant Logout', () => {
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
         expect(searchParams.get('redirect_url')).toBeFalsy();
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
 
@@ -651,10 +639,7 @@ describe('Multi Tenant Logout', () => {
         loginUrl = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/login`;
         redirectUri = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -699,7 +684,7 @@ describe('Multi Tenant Logout', () => {
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
         expect(searchParams.get('redirect_url')).toBeFalsy();
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
 
@@ -709,10 +694,7 @@ describe('Multi Tenant Logout', () => {
       loginUrl = `https://${parseTenantFromRootDomain}/api/auth/login`;
       redirectUri = `https://${parseTenantFromRootDomain}/api/auth/callback`;
 
-      const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-        .reply(200);
+      mockFetchRevoke(200);
 
       wristbandAuth = createWristbandAuth({
         clientId: CLIENT_ID,
@@ -757,7 +739,7 @@ describe('Multi Tenant Logout', () => {
       expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
       expect(searchParams.get('redirect_url')).toBeFalsy();
 
-      scope.done();
+      expectRevokeCalled(wristbandApplicationVanityDomain);
     });
 
     test('Custom Domains with Tenant Custom Domain, without subdomains, with tenantName config', async () => {
@@ -766,10 +748,7 @@ describe('Multi Tenant Logout', () => {
       loginUrl = `https://${parseTenantFromRootDomain}/api/auth/login`;
       redirectUri = `https://${parseTenantFromRootDomain}/api/auth/callback`;
 
-      const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-        .reply(200);
+      mockFetchRevoke(200);
 
       wristbandAuth = createWristbandAuth({
         clientId: CLIENT_ID,
@@ -815,7 +794,7 @@ describe('Multi Tenant Logout', () => {
       expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
       expect(searchParams.get('redirect_url')).toBeFalsy();
 
-      scope.done();
+      expectRevokeCalled(wristbandApplicationVanityDomain);
     });
 
     describe.each([
@@ -828,10 +807,7 @@ describe('Multi Tenant Logout', () => {
         loginUrl = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/login`;
         redirectUri = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -877,7 +853,7 @@ describe('Multi Tenant Logout', () => {
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
         expect(searchParams.get('redirect_url')).toBeFalsy();
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
 
       test('with tenantName config', async () => {
@@ -886,10 +862,7 @@ describe('Multi Tenant Logout', () => {
         loginUrl = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/login`;
         redirectUri = `https://${placeholder}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(200);
+        mockFetchRevoke(200);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -936,7 +909,7 @@ describe('Multi Tenant Logout', () => {
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
         expect(searchParams.get('redirect_url')).toBeFalsy();
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
 
@@ -946,10 +919,7 @@ describe('Multi Tenant Logout', () => {
       loginUrl = `https://{tenant_name}.${parseTenantFromRootDomain}/api/auth/login`;
       redirectUri = `https://{tenant_name}.${parseTenantFromRootDomain}/api/auth/callback`;
 
-      const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-        .reply(200);
+      mockFetchRevoke(200);
 
       wristbandAuth = createWristbandAuth({
         clientId: CLIENT_ID,
@@ -994,7 +964,7 @@ describe('Multi Tenant Logout', () => {
       expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
       expect(searchParams.get('redirect_url')).toBeFalsy();
 
-      scope.done();
+      expectRevokeCalled(wristbandApplicationVanityDomain);
     });
 
     test('Tenant Domain with Tenant Name query param', async () => {
@@ -1003,10 +973,7 @@ describe('Multi Tenant Logout', () => {
       loginUrl = `https://${parseTenantFromRootDomain}/api/auth/login`;
       redirectUri = `https://${parseTenantFromRootDomain}/api/auth/callback`;
 
-      const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-        .persist()
-        .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-        .reply(200);
+      mockFetchRevoke(200);
 
       wristbandAuth = createWristbandAuth({
         clientId: CLIENT_ID,
@@ -1049,7 +1016,7 @@ describe('Multi Tenant Logout', () => {
       expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
       expect(searchParams.get('redirect_url')).toBeFalsy();
 
-      scope.done();
+      expectRevokeCalled(wristbandApplicationVanityDomain);
     });
 
     describe('Refresh Token Edge Cases', () => {
@@ -1101,10 +1068,7 @@ describe('Multi Tenant Logout', () => {
       });
 
       test('Revoke Token Failure', async () => {
-        const scope = nock(`https://${wristbandApplicationVanityDomain}`)
-          .persist()
-          .post('/api/v1/oauth2/revoke', 'token=refreshToken')
-          .reply(401);
+        mockFetchRevoke(401);
 
         wristbandAuth = createWristbandAuth({
           clientId: CLIENT_ID,
@@ -1148,7 +1112,7 @@ describe('Multi Tenant Logout', () => {
         // Validate query params of Logout URL
         expect(searchParams.get('client_id')).toEqual(CLIENT_ID);
 
-        scope.done();
+        expectRevokeCalled(wristbandApplicationVanityDomain);
       });
     });
   });

--- a/test/refresh-token-if-expired/error.test.ts
+++ b/test/refresh-token-if-expired/error.test.ts
@@ -1,6 +1,4 @@
-import nock from 'nock';
-
-import { createWristbandAuth, WristbandAuth, WristbandError } from '../../src/index';
+import { createWristbandAuth, WristbandAuth, WristbandError } from '../../src';
 
 const CLIENT_ID = 'clientId';
 const CLIENT_SECRET = 'clientSecret';
@@ -8,6 +6,7 @@ const LOGIN_STATE_COOKIE_SECRET = '7ffdbecc-ab7d-4134-9307-2dfcc52f7475';
 const LOGIN_URL = 'http://localhost:6001/api/auth/login';
 const REDIRECT_URI = 'http://localhost:6001/api/auth/callback';
 const WRISTBAND_APPLICATION_DOMAIN = 'invotasticb2c-invotastic.dev.wristband.dev';
+const TOKEN_ENDPOINT = `https://${WRISTBAND_APPLICATION_DOMAIN}/api/v1/oauth2/token`;
 
 const wristbandAuth: WristbandAuth = createWristbandAuth({
   clientId: CLIENT_ID,
@@ -19,9 +18,23 @@ const wristbandAuth: WristbandAuth = createWristbandAuth({
   autoConfigureEnabled: false,
 });
 
+function mockFetchToken(status: number, body: unknown) {
+  const bodyText = JSON.stringify(body);
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return 'application/json';
+      },
+    },
+    text: jest.fn().mockResolvedValue(bodyText),
+  });
+}
+
 describe('Refresh Token Errors', () => {
-  beforeEach(() => {
-    nock.cleanAll();
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test('Invalid refreshToken', async () => {
@@ -45,32 +58,30 @@ describe('Refresh Token Errors', () => {
   });
 
   test('Perform a token refresh with a bad token value', async () => {
-    const mockError = {
-      error: 'invalid_grant',
-      error_description: 'Invalid refresh token',
-    };
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .persist()
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(400, mockError);
+    const mockError = { error: 'invalid_grant', error_description: 'Invalid refresh token' };
+    mockFetchToken(400, mockError);
 
     try {
       await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now().valueOf() - 1000);
       fail('Error expected to be thrown.');
     } catch (error: any) {
       expect(error instanceof WristbandError).toBe(true);
-      expect(error.code).toBe('invalid_grant');
+      expect(error.code).toBe('invalid_refresh_token');
       expect(error.errorDescription).toBe('Invalid refresh token');
     }
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      TOKEN_ENDPOINT,
+      expect.objectContaining({
+        method: 'POST',
+        body: 'grant_type=refresh_token&refresh_token=refreshToken',
+      })
+    );
   });
 
   test('Perform a token refresh with a server error', async () => {
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .persist()
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(500);
+    mockFetchToken(500, { error: 'server_error' });
 
     try {
       await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now().valueOf() - 1000);
@@ -81,6 +92,6 @@ describe('Refresh Token Errors', () => {
       expect(error.errorDescription).toBe('Unexpected Error');
     }
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(3); // All 3 retry attempts exhausted
   });
 });

--- a/test/refresh-token-if-expired/refresh-token-if-expired.test.ts
+++ b/test/refresh-token-if-expired/refresh-token-if-expired.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
-import nock from 'nock';
 import { WristbandAuth } from '../../src/wristband-auth';
 import { createWristbandAuth, WristbandError } from '../../src/index';
 
@@ -10,6 +7,7 @@ const LOGIN_STATE_COOKIE_SECRET = '7ffdbecc-ab7d-4134-9307-2dfcc52f7475';
 const LOGIN_URL = 'http://localhost:6001/api/auth/login';
 const REDIRECT_URI = 'http://localhost:6001/api/auth/callback';
 const WRISTBAND_APPLICATION_DOMAIN = 'invotasticb2c-invotastic.dev.wristband.dev';
+const TOKEN_ENDPOINT = `https://${WRISTBAND_APPLICATION_DOMAIN}/api/v1/oauth2/token`;
 
 let wristbandAuth: WristbandAuth;
 
@@ -25,11 +23,30 @@ beforeEach(() => {
   });
 });
 
-describe('Refresh Token If Expired', () => {
-  beforeEach(() => {
-    nock.cleanAll();
-  });
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
+function mockFetchToken(responses: { status: number; body: unknown }[]) {
+  let callCount = 0;
+  global.fetch = jest.fn().mockImplementation(() => {
+    const response = responses[Math.min(callCount, responses.length - 1)];
+    callCount += 1;
+    const bodyText = JSON.stringify(response.body);
+    return Promise.resolve({
+      status: response.status,
+      ok: response.status >= 200 && response.status < 300,
+      headers: {
+        get: () => {
+          return 'application/json';
+        },
+      },
+      text: jest.fn().mockResolvedValue(bodyText),
+    });
+  });
+}
+
+describe('Refresh Token If Expired', () => {
   test('Token is not expired', async () => {
     // Choose some arbitrary time in the future from the current time (in milliseconds)
     const tokenData = await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now().valueOf() + 1000000);
@@ -44,42 +61,43 @@ describe('Refresh Token If Expired', () => {
       refresh_token: 'refreshToken',
       token_type: 'bearer',
     };
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .persist()
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(200, mockTokens);
+    mockFetchToken([{ status: 200, body: mockTokens }]);
 
     const tokenData = await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now().valueOf() - 1000);
+
     expect(tokenData).toBeDefined();
     expect(tokenData?.accessToken).toBe('accessToken');
     expect(tokenData?.expiresAt).toBeGreaterThanOrEqual(Date.now());
     expect(tokenData?.expiresIn).toBe(1740);
     expect(tokenData?.idToken).toBe('idToken');
     expect(tokenData?.refreshToken).toBe('refreshToken');
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      TOKEN_ENDPOINT,
+      expect.objectContaining({
+        method: 'POST',
+        body: 'grant_type=refresh_token&refresh_token=refreshToken',
+      })
+    );
   });
 
   test('Token is expired, but refresh token is invalid', async () => {
     const errorResponse = { error: 'invalid_grant', error_description: 'The refresh token is invalid or has expired' };
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .persist()
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=invalidToken')
-      .reply(400, errorResponse);
+    mockFetchToken([{ status: 400, body: errorResponse }]);
 
     try {
       await wristbandAuth.refreshTokenIfExpired('invalidToken', Date.now().valueOf() - 1000);
       fail('Expected an error to be thrown');
     } catch (error) {
       expect(error).toBeInstanceOf(WristbandError);
-      expect((error as WristbandError).code).toBe('invalid_grant');
+      expect((error as WristbandError).code).toBe('invalid_refresh_token');
       expect((error as WristbandError).errorDescription).toBe(errorResponse.error_description);
     }
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Token refresh with custom tokenExpirationBuffer', async () => {
-    // Create wristbandAuth with custom buffer
     const customBufferAuth = createWristbandAuth({
       clientId: CLIENT_ID,
       clientSecret: CLIENT_SECRET,
@@ -98,16 +116,13 @@ describe('Refresh Token If Expired', () => {
       refresh_token: 'refreshToken',
       token_type: 'bearer',
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(200, mockTokens);
+    mockFetchToken([{ status: 200, body: mockTokens }]);
 
     const tokenData = await customBufferAuth.refreshTokenIfExpired('refreshToken', Date.now() - 1000);
 
     expect(tokenData).toBeDefined();
     expect(tokenData?.expiresIn).toBe(1680); // 1800 - 120 (custom buffer)
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Token refresh with zero tokenExpirationBuffer', async () => {
@@ -129,21 +144,16 @@ describe('Refresh Token If Expired', () => {
       refresh_token: 'refreshToken',
       token_type: 'bearer',
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(200, mockTokens);
+    mockFetchToken([{ status: 200, body: mockTokens }]);
 
     const tokenData = await zeroBufferAuth.refreshTokenIfExpired('refreshToken', Date.now() - 1000);
 
     expect(tokenData?.expiresIn).toBe(1800); // No buffer applied
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Token at exact expiration boundary', async () => {
     const currentTime = Date.now();
-
-    // Mock the HTTP call since token will be considered expired
     const mockTokens = {
       access_token: 'accessToken',
       expires_in: 1800,
@@ -151,12 +161,8 @@ describe('Refresh Token If Expired', () => {
       refresh_token: 'refreshToken',
       token_type: 'bearer',
     };
+    mockFetchToken([{ status: 200, body: mockTokens }]);
 
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(200, mockTokens);
-
-    // Mock Date.now to return consistent time
     const mockDateNow = jest.spyOn(Date, 'now').mockReturnValue(currentTime);
 
     const tokenData = await wristbandAuth.refreshTokenIfExpired('refreshToken', currentTime);
@@ -164,9 +170,9 @@ describe('Refresh Token If Expired', () => {
     // At exact expiration time, token should be considered expired and refreshed
     expect(tokenData).toBeDefined();
     expect(tokenData?.accessToken).toBe('accessToken');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
 
     mockDateNow.mockRestore();
-    scope.done();
   });
 
   test('ExpiresAt calculation includes buffer correctly', async () => {
@@ -177,10 +183,7 @@ describe('Refresh Token If Expired', () => {
       refresh_token: 'newRefreshToken',
       token_type: 'bearer',
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(200, mockTokens);
+    mockFetchToken([{ status: 200, body: mockTokens }]);
 
     const beforeRefresh = Date.now();
     const tokenData = await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now() - 1000);
@@ -195,7 +198,7 @@ describe('Refresh Token If Expired', () => {
     expect(tokenData?.expiresAt).toBeGreaterThanOrEqual(expectedExpiresAt);
     expect(tokenData?.expiresAt).toBeLessThanOrEqual(afterRefresh + 3540 * 1000);
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Handles server error with retry logic (5xx errors)', async () => {
@@ -208,19 +211,17 @@ describe('Refresh Token If Expired', () => {
     };
 
     // First two calls return 500, third succeeds
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(500, { error: 'server_error' })
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(500, { error: 'server_error' })
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(200, mockTokens);
+    mockFetchToken([
+      { status: 500, body: { error: 'server_error' } },
+      { status: 500, body: { error: 'server_error' } },
+      { status: 200, body: mockTokens },
+    ]);
 
     const tokenData = await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now() - 1000);
 
     expect(tokenData).toBeDefined();
     expect(tokenData?.accessToken).toBe('accessToken');
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
   test('Handles 4xx client error without retry', async () => {
@@ -228,27 +229,21 @@ describe('Refresh Token If Expired', () => {
       error: 'invalid_client',
       error_description: 'Client authentication failed',
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(401, errorResponse);
+    mockFetchToken([{ status: 401, body: errorResponse }]);
 
     await expect(wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now() - 1000)).rejects.toThrow(
       WristbandError
     );
 
     // Should only make one call (no retry for 4xx)
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Handles 4xx error without error_description', async () => {
     const errorResponse = {
       error: 'invalid_request',
     };
-
-    const scope = nock(`https://${WRISTBAND_APPLICATION_DOMAIN}`)
-      .post('/api/v1/oauth2/token', 'grant_type=refresh_token&refresh_token=refreshToken')
-      .reply(400, errorResponse);
+    mockFetchToken([{ status: 400, body: errorResponse }]);
 
     try {
       await wristbandAuth.refreshTokenIfExpired('refreshToken', Date.now() - 1000);
@@ -259,7 +254,7 @@ describe('Refresh Token If Expired', () => {
       expect((error as WristbandError).errorDescription).toBe('Invalid Refresh Token'); // Default description
     }
 
-    scope.done();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Parameter validation - empty refresh token', async () => {

--- a/test/utils/index.test.ts
+++ b/test/utils/index.test.ts
@@ -15,6 +15,7 @@ import {
   createLoginStateCookie,
   getOAuthAuthorizeUrl,
   isExpired,
+  encodeBase64,
 } from '../../src/utils';
 import { LoginState, LoginStateMapConfig } from '../../src/types';
 
@@ -758,6 +759,36 @@ describe('Auth Utils', () => {
       }).toThrow('More than one [login_hint] query parameter was encountered');
     });
 
+    test('Includes idp hint when provided in query', () => {
+      const req = httpMocks.createRequest({
+        query: { idp_hint: 'google' },
+      }) as any;
+
+      const config = {
+        ...baseConfig,
+        tenantCustomDomain: 'tenant.custom.com',
+      };
+
+      const result = getOAuthAuthorizeUrl(req, config);
+
+      expect(result).toContain('idp_hint=google');
+    });
+
+    test('Throws error for multiple idp_hint query parameters', () => {
+      const req = httpMocks.createRequest({
+        query: { idp_hint: ['google', 'github'] },
+      }) as any;
+
+      const config = {
+        ...baseConfig,
+        tenantCustomDomain: 'tenant.custom.com',
+      };
+
+      expect(() => {
+        return getOAuthAuthorizeUrl(req, config);
+      }).toThrow('More than one [idp_hint] query parameter was encountered');
+    });
+
     test('Includes all required OAuth parameters', () => {
       const req = httpMocks.createRequest() as any;
 
@@ -842,6 +873,26 @@ describe('Auth Utils', () => {
       const result = isExpired(0);
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('encodeBase64', () => {
+    test('Encodes a simple ASCII string', () => {
+      expect(encodeBase64('hello')).toBe(btoa('hello'));
+    });
+
+    test('Encodes clientId:clientSecret format correctly', () => {
+      const input = 'myClientId:myClientSecret';
+      expect(encodeBase64(input)).toBe(btoa(input));
+    });
+
+    test('Encodes empty string', () => {
+      expect(encodeBase64('')).toBe('');
+    });
+
+    test('Produces valid base64 output', () => {
+      const result = encodeBase64('test-input');
+      expect(result).toMatch(/^[A-Za-z0-9+/]+=*$/);
     });
   });
 });

--- a/test/wristband-api-client.test.ts
+++ b/test/wristband-api-client.test.ts
@@ -1,250 +1,250 @@
-import axios from 'axios';
 import { WristbandApiClient } from '../src/wristband-api-client';
+import { FetchError } from '../src/error/fetch-error';
 import { FORM_URLENCODED_MEDIA_TYPE, JSON_MEDIA_TYPE } from '../src/utils/constants';
 
-// Mock axios.create to avoid actual HTTP calls
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+const WRISTBAND_DOMAIN = 'test.wristband.dev';
+const BASE_URL = `https://${WRISTBAND_DOMAIN}/api/v1`;
+
+function mockFetch(status: number, body: unknown, contentType = 'application/json') {
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return contentType;
+      },
+    },
+    text: jest.fn().mockResolvedValue(bodyText),
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
 
 describe('WristbandApiClient', () => {
-  const WRISTBAND_DOMAIN = 'test.wristband.dev';
-  let wristbandApiClient: WristbandApiClient;
-  let mockAxiosInstance: any;
+  let client: WristbandApiClient;
 
   beforeEach(() => {
-    mockAxiosInstance = {
-      get: jest.fn(),
-      post: jest.fn(),
-      put: jest.fn(),
-      delete: jest.fn(),
-      patch: jest.fn(),
-      request: jest.fn(),
-    };
-    mockedAxios.create.mockReturnValue(mockAxiosInstance);
-    wristbandApiClient = new WristbandApiClient(WRISTBAND_DOMAIN);
+    client = new WristbandApiClient(WRISTBAND_DOMAIN);
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   describe('Constructor', () => {
-    test('Creates axios instance with correct base URL', () => {
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${WRISTBAND_DOMAIN}/api/v1` })
-      );
+    test('Sets correct base URL from domain', () => {
+      mockFetch(200, {});
+      client.get('/test');
+      expect(global.fetch).toHaveBeenCalledWith(`${BASE_URL}/test`, expect.any(Object));
     });
 
-    test('Sets correct default headers', () => {
-      expect(mockedAxios.create).toHaveBeenCalledWith(
+    test('Sets default Content-Type and Accept headers', () => {
+      mockFetch(200, {});
+      client.get('/test');
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          headers: { 'Content-Type': FORM_URLENCODED_MEDIA_TYPE, Accept: JSON_MEDIA_TYPE },
+          headers: expect.objectContaining({
+            'Content-Type': FORM_URLENCODED_MEDIA_TYPE,
+            Accept: JSON_MEDIA_TYPE,
+          }),
         })
       );
     });
 
-    test('Configures HTTP agent with correct settings', () => {
-      const createCall = mockedAxios.create.mock.calls[0]?.[0];
-      expect(createCall).toBeDefined();
-      expect(createCall!.httpAgent).toBeDefined();
-      expect(createCall!.httpAgent.keepAlive).toBe(true);
-      expect(createCall!.httpAgent.maxSockets).toBe(100);
-      expect(createCall!.httpAgent.maxFreeSockets).toBe(10);
-      expect(createCall!.httpAgent.options.timeout).toBe(60000);
-      expect(createCall!.httpAgent.keepAliveMsecs).toBe(1000);
-      expect(createCall!.httpAgent.scheduling).toBe('lifo');
-    });
-
-    test('Configures HTTPS agent with correct settings', () => {
-      const createCall = mockedAxios.create.mock.calls[0]?.[0];
-      expect(createCall).toBeDefined();
-      expect(createCall!.httpsAgent).toBeDefined();
-      expect(createCall!.httpsAgent.keepAlive).toBe(true);
-      expect(createCall!.httpsAgent.maxSockets).toBe(100);
-      expect(createCall!.httpsAgent.maxFreeSockets).toBe(10);
-      expect(createCall!.httpsAgent.options.timeout).toBe(60000);
-      expect(createCall!.httpsAgent.keepAliveMsecs).toBe(1000);
-      expect(createCall!.httpsAgent.scheduling).toBe('lifo');
-    });
-
-    test('Disables redirects', () => {
-      expect(mockedAxios.create).toHaveBeenCalledWith(expect.objectContaining({ maxRedirects: 0 }));
-    });
-
-    test('Exposes axios instance publicly', () => {
-      expect(wristbandApiClient.axiosInstance).toBe(mockAxiosInstance);
+    test('Handles different domains correctly', () => {
+      const otherClient = new WristbandApiClient('other.wristband.dev');
+      mockFetch(200, {});
+      otherClient.get('/test');
+      expect(global.fetch).toHaveBeenCalledWith('https://other.wristband.dev/api/v1/test', expect.any(Object));
     });
   });
 
-  describe('Multiple instances', () => {
-    test('Creates axios instances for different domains', () => {
-      const domain1 = 'domain1.wristband.dev';
-      const domain2 = 'domain2.wristband.dev';
+  describe('get()', () => {
+    test('Makes GET request to correct URL', async () => {
+      mockFetch(200, { result: 'ok' });
+      await client.get('/oauth2/userinfo');
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/oauth2/userinfo`,
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
 
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(domain1);
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(domain2);
+    test('Returns parsed JSON body on success', async () => {
+      const responseBody = { sub: 'user-123', tnt_id: 'tenant-abc' };
+      mockFetch(200, responseBody);
+      const result = await client.get('/oauth2/userinfo');
+      expect(result).toEqual(responseBody);
+    });
 
-      // Including the beforeEach call
-      expect(mockedAxios.create).toHaveBeenCalledTimes(3);
+    test('Merges per-request headers with defaults', async () => {
+      mockFetch(200, {});
+      await client.get('/test', { Authorization: 'Bearer token123' });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': FORM_URLENCODED_MEDIA_TYPE,
+            Accept: JSON_MEDIA_TYPE,
+            Authorization: 'Bearer token123',
+          }),
+        })
+      );
+    });
 
-      const calls = mockedAxios.create.mock.calls.map((call) => {
-        return call[0]?.baseURL;
+    test('Per-request headers override defaults', async () => {
+      mockFetch(200, {});
+      await client.get('/test', { 'Content-Type': JSON_MEDIA_TYPE });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'Content-Type': JSON_MEDIA_TYPE }),
+        })
+      );
+    });
+
+    test('Sets keepalive to true', async () => {
+      mockFetch(200, {});
+      await client.get('/test');
+      expect(global.fetch).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ keepalive: true }));
+    });
+
+    test('Throws FetchError on 400 response', async () => {
+      const errorBody = { error: 'bad_request', error_description: 'Invalid request' };
+      mockFetch(400, errorBody);
+      await expect(client.get('/test')).rejects.toThrow(FetchError);
+    });
+
+    test('Throws FetchError on 401 response', async () => {
+      mockFetch(401, { error: 'unauthorized' });
+      await expect(client.get('/test')).rejects.toThrow(FetchError);
+    });
+
+    test('Throws FetchError on 500 response', async () => {
+      mockFetch(500, { error: 'server_error' });
+      await expect(client.get('/test')).rejects.toThrow(FetchError);
+    });
+
+    test('FetchError carries correct status and body', async () => {
+      const errorBody = { error: 'invalid_grant', error_description: 'Code expired' };
+      mockFetch(400, errorBody);
+      try {
+        await client.get('/test');
+        fail('Expected FetchError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchError);
+        const fetchError = err as FetchError<Response>;
+        expect(fetchError.response?.status).toBe(400);
+        expect(fetchError.body).toEqual(errorBody);
+      }
+    });
+
+    test('Returns undefined on 204 No Content', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 204,
+        ok: true,
+        headers: {
+          get: () => {
+            return null;
+          },
+        },
+        text: jest.fn().mockResolvedValue(''),
       });
-
-      expect(calls).toContain(`https://${domain1}/api/v1`);
-      expect(calls).toContain(`https://${domain2}/api/v1`);
+      const result = await client.get('/test');
+      expect(result).toBeUndefined();
     });
   });
 
-  describe('Domain handling', () => {
-    test('Handles domain with protocol (strips it)', () => {
-      const domainWithProtocol = 'https://test.wristband.dev';
-
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(domainWithProtocol);
-
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${domainWithProtocol}/api/v1` })
+  describe('post()', () => {
+    test('Makes POST request to correct URL', async () => {
+      mockFetch(200, { access_token: 'token', expires_in: 3600 });
+      await client.post('/oauth2/token', 'grant_type=authorization_code&code=abc');
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/oauth2/token`,
+        expect.objectContaining({ method: 'POST' })
       );
     });
 
-    test('Handles domain with path (includes it)', () => {
-      const domainWithPath = 'test.wristband.dev/custom';
+    test('Sends body in request', async () => {
+      mockFetch(200, {});
+      const body = 'grant_type=refresh_token&refresh_token=abc123';
+      await client.post('/oauth2/token', body);
+      expect(global.fetch).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ body }));
+    });
 
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(domainWithPath);
+    test('Returns parsed JSON body on success', async () => {
+      const responseBody = { access_token: 'token123', expires_in: 3600 };
+      mockFetch(200, responseBody);
+      const result = await client.post('/oauth2/token', 'grant_type=refresh_token&refresh_token=abc');
+      expect(result).toEqual(responseBody);
+    });
 
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${domainWithPath}/api/v1` })
+    test('Merges per-request headers with defaults', async () => {
+      mockFetch(200, {});
+      await client.post('/oauth2/token', 'body', { Authorization: 'Basic dXNlcjpwYXNz' });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': FORM_URLENCODED_MEDIA_TYPE,
+            Accept: JSON_MEDIA_TYPE,
+            Authorization: 'Basic dXNlcjpwYXNz',
+          }),
+        })
       );
     });
 
-    test('Handles domain with port', () => {
-      const domainWithPort = 'test.wristband.dev:8080';
-
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(domainWithPort);
-
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${domainWithPort}/api/v1` })
-      );
+    test('Sets keepalive to true', async () => {
+      mockFetch(200, {});
+      await client.post('/test', 'body');
+      expect(global.fetch).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ keepalive: true }));
     });
 
-    test('Handles empty domain', () => {
-      const emptyDomain = '';
-
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(emptyDomain);
-
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${emptyDomain}/api/v1` })
-      );
-    });
-  });
-
-  describe('Agent configuration validation', () => {
-    test('HTTP and HTTPS agents have identical configurations', () => {
-      const createCall = mockedAxios.create.mock.calls[0]?.[0];
-      expect(createCall).toBeDefined();
-
-      const httpAgent = createCall!.httpAgent;
-      const httpsAgent = createCall!.httpsAgent;
-
-      // Compare all properties
-      expect(httpAgent.keepAlive).toBe(httpsAgent.keepAlive);
-      expect(httpAgent.maxSockets).toBe(httpsAgent.maxSockets);
-      expect(httpAgent.maxFreeSockets).toBe(httpsAgent.maxFreeSockets);
-      expect(httpAgent.timeout).toBe(httpsAgent.timeout);
-      expect(httpAgent.keepAliveMsecs).toBe(httpsAgent.keepAliveMsecs);
-      expect(httpAgent.scheduling).toBe(httpsAgent.scheduling);
+    test('Throws FetchError on 400 response', async () => {
+      const errorBody = { error: 'invalid_grant', error_description: 'Invalid code' };
+      mockFetch(400, errorBody);
+      await expect(client.post('/oauth2/token', 'grant_type=authorization_code&code=bad')).rejects.toThrow(FetchError);
     });
 
-    test('Uses different agent constructors for HTTP and HTTPS', () => {
-      const createCall = mockedAxios.create.mock.calls[0]?.[0];
-      expect(createCall).toBeDefined();
+    test('FetchError carries correct status and body', async () => {
+      const errorBody = { error: 'invalid_grant', error_description: 'Refresh token expired' };
+      mockFetch(400, errorBody);
+      try {
+        await client.post('/oauth2/token', 'grant_type=refresh_token&refresh_token=expired');
+        fail('Expected FetchError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchError);
+        const fetchError = err as FetchError<Response>;
+        expect(fetchError.response?.status).toBe(400);
+        expect(fetchError.body).toEqual(errorBody);
+      }
+    });
 
-      // Verify that different constructors were used
-      expect(createCall!.httpAgent.constructor.name).toBe('Agent');
-      expect(createCall!.httpsAgent.constructor.name).toBe('Agent');
+    test('Returns undefined on 204 No Content', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 204,
+        ok: true,
+        headers: {
+          get: () => {
+            return null;
+          },
+        },
+        text: jest.fn().mockResolvedValue(''),
+      });
+      const result = await client.post('/oauth2/revoke', 'token=abc');
+      expect(result).toBeUndefined();
+    });
 
-      // They should be different instances
-      expect(createCall!.httpAgent).not.toBe(createCall!.httpsAgent);
+    test('Throws FetchError on 500 response', async () => {
+      mockFetch(500, { error: 'server_error' });
+      await expect(client.post('/oauth2/token', 'body')).rejects.toThrow(FetchError);
     });
   });
 
   describe('Configuration constants', () => {
     test('Uses correct media type constants', () => {
-      // This test ensures the constants are properly imported and used
       expect(FORM_URLENCODED_MEDIA_TYPE).toBe('application/x-www-form-urlencoded');
       expect(JSON_MEDIA_TYPE).toBe('application/json;charset=UTF-8');
-
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json;charset=UTF-8' },
-        })
-      );
-    });
-  });
-
-  describe('Instance behavior', () => {
-    test('Axios instance methods are available', () => {
-      expect(wristbandApiClient.axiosInstance.get).toBeDefined();
-      expect(wristbandApiClient.axiosInstance.post).toBeDefined();
-      expect(wristbandApiClient.axiosInstance.put).toBeDefined();
-      expect(wristbandApiClient.axiosInstance.delete).toBeDefined();
-      expect(wristbandApiClient.axiosInstance.patch).toBeDefined();
-      expect(wristbandApiClient.axiosInstance.request).toBeDefined();
-    });
-
-    test('Can make HTTP requests through the axios instance', async () => {
-      const mockResponse = { data: { test: 'data' }, status: 200 };
-      mockAxiosInstance.get.mockResolvedValue(mockResponse);
-      const response = await wristbandApiClient.axiosInstance.get('/test-endpoint');
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/test-endpoint');
-      expect(response).toBe(mockResponse);
-    });
-
-    test('Axios instance inherits all configuration', async () => {
-      const mockResponse = { data: { test: 'data' }, status: 200 };
-      mockAxiosInstance.post.mockResolvedValue(mockResponse);
-      await wristbandApiClient.axiosInstance.post('/test', { data: 'test' });
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/test', { data: 'test' });
-    });
-  });
-
-  describe('Edge cases', () => {
-    test('Handles special characters in domain', () => {
-      const specialDomain = 'test-domain_123.wristband.dev';
-
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(specialDomain);
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${specialDomain}/api/v1` })
-      );
-    });
-
-    test('Handles very long domain names', () => {
-      const longDomain = `${'a'.repeat(100)}.wristband.dev`;
-
-      // eslint-disable-next-line no-new
-      new WristbandApiClient(longDomain);
-      expect(mockedAxios.create).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: `https://${longDomain}/api/v1` })
-      );
-    });
-
-    test('Configuration is immutable after creation', () => {
-      const createCall = mockedAxios.create.mock.calls[0]?.[0];
-      expect(createCall).toBeDefined();
-      const originalBaseURL = createCall!.baseURL;
-
-      // Attempt to modify the configuration (this shouldn't affect the instance)
-      createCall!.baseURL = 'https://different.domain.com/api/v1';
-
-      // The axios instance should still use the original configuration
-      expect(originalBaseURL).toBe(`https://${WRISTBAND_DOMAIN}/api/v1`);
     });
   });
 });

--- a/test/wristband-service/basic.test.ts
+++ b/test/wristband-service/basic.test.ts
@@ -1,273 +1,385 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
-import nock from 'nock';
 import { WristbandService } from '../../src/wristband-service';
+import { FetchError } from '../../src/error/fetch-error';
+import { InvalidGrantError } from '../../src/error';
 import { SdkConfiguration, WristbandTokenResponse, WristbandUserinfoResponse, UserInfo } from '../../src/types';
+import { JSON_MEDIA_TYPE } from '../../src/utils/constants';
 
 const DOMAIN = 'your-wristband-domain';
 const CLIENT_ID = 'test-client-id';
 const CLIENT_SECRET = 'test-client-secret';
+const BASE_URL = `https://${DOMAIN}/api/v1`;
+const EXPECTED_BASIC_AUTH = `Basic ${btoa(`${CLIENT_ID}:${CLIENT_SECRET}`)}`;
 
-describe('WristbandService - Basic Functionality', () => {
+function mockFetch(status: number, body: unknown) {
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return 'application/json';
+      },
+    },
+    text: jest.fn().mockResolvedValue(bodyText),
+  });
+}
+
+describe('WristbandService', () => {
   let wristbandService: WristbandService;
 
   beforeEach(() => {
-    nock.cleanAll();
     wristbandService = new WristbandService(DOMAIN, CLIENT_ID, CLIENT_SECRET);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('Constructor', () => {
-    test('Creates instance with correct properties', () => {
+    test('Creates instance successfully', () => {
       expect(wristbandService).toBeDefined();
     });
-  });
 
-  describe('SDK Configuration', () => {
-    describe('getSdkConfiguration', () => {
-      test('Returns SDK configuration successfully', async () => {
-        const expectedSdkConfig: SdkConfiguration = {
-          customApplicationLoginPageUrl: 'https://custom.example.com/login',
-          isApplicationCustomDomainActive: true,
-          loginUrl: 'https://your-wristband-domain/login',
-          loginUrlTenantDomainSuffix: '.tenant',
-          redirectUri: 'https://app.example.com/callback',
-        };
+    test('Throws when domain is missing', () => {
+      expect(() => {
+        return new WristbandService('', CLIENT_ID, CLIENT_SECRET);
+      }).toThrow('Wristband application domain is required');
+    });
 
-        const scope = nock(`https://${DOMAIN}`)
-          .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-          .reply(200, expectedSdkConfig);
+    test('Throws when domain is whitespace', () => {
+      expect(() => {
+        return new WristbandService('   ', CLIENT_ID, CLIENT_SECRET);
+      }).toThrow('Wristband application domain is required');
+    });
 
-        const result = await wristbandService.getSdkConfiguration();
-        expect(result).toEqual(expectedSdkConfig);
-        scope.done();
-      });
+    test('Throws when clientId is missing', () => {
+      expect(() => {
+        return new WristbandService(DOMAIN, '', CLIENT_SECRET);
+      }).toThrow('Client ID is required');
+    });
+
+    test('Throws when clientSecret is missing', () => {
+      expect(() => {
+        return new WristbandService(DOMAIN, CLIENT_ID, '');
+      }).toThrow('Client secret is required');
     });
   });
 
-  describe('Token Operations', () => {
-    describe('getTokens', () => {
-      test('With valid request returns token response', async () => {
-        const code = 'valid-auth-code';
-        const redirectUri = 'https://app.example.com/callback';
-        const codeVerifier = 'valid-code-verifier';
+  describe('getSdkConfiguration', () => {
+    test('Returns SDK configuration successfully', async () => {
+      const expectedSdkConfig: SdkConfiguration = {
+        customApplicationLoginPageUrl: 'https://custom.example.com/login',
+        isApplicationCustomDomainActive: true,
+        loginUrl: 'https://your-wristband-domain/login',
+        loginUrlTenantDomainSuffix: '.tenant',
+        redirectUri: 'https://app.example.com/callback',
+      };
+      mockFetch(200, expectedSdkConfig);
 
-        const expectedResponse: WristbandTokenResponse = {
-          access_token: 'new-access-token',
-          refresh_token: 'new-refresh-token',
-          id_token: 'new-id-token',
-          expires_in: 3600,
-          token_type: 'bearer',
-        };
+      const result = await wristbandService.getSdkConfiguration();
 
-        const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, expectedResponse);
-
-        const result = await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        expect(result).toEqual(expectedResponse);
-        scope.done();
-      });
-
-      test('Sends correct form parameters in request body', async () => {
-        const code = 'test-code';
-        const redirectUri = 'https://app.example.com/callback';
-        const codeVerifier = 'test-verifier';
-
-        const expectedResponse: WristbandTokenResponse = {
-          access_token: 'access-token',
-          refresh_token: 'refresh-token',
-          id_token: 'id-token',
-          expires_in: 3600,
-          token_type: 'bearer',
-        };
-        const expectedFormData = `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&code_verifier=${codeVerifier}`;
-        const scope = nock(`https://${DOMAIN}`)
-          .post('/api/v1/oauth2/token', expectedFormData)
-          .reply(200, expectedResponse);
-
-        const result = await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        expect(result).toEqual(expectedResponse);
-        scope.done();
-      });
+      expect(result).toEqual(expectedSdkConfig);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/clients/${CLIENT_ID}/sdk-configuration`,
+        expect.objectContaining({ method: 'GET' })
+      );
     });
 
-    describe('refreshToken', () => {
-      test('With valid token returns token response', async () => {
-        const refreshToken = 'valid-refresh-token';
+    test('Sends JSON content-type and accept headers', async () => {
+      mockFetch(200, {});
 
-        const expectedResponse: WristbandTokenResponse = {
-          access_token: 'new-access-token',
-          refresh_token: 'new-refresh-token',
-          id_token: 'new-id-token',
-          expires_in: 3600,
-          token_type: 'bearer',
-        };
+      await wristbandService.getSdkConfiguration();
 
-        const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, expectedResponse);
-
-        const result = await wristbandService.refreshToken(refreshToken);
-        expect(result).toEqual(expectedResponse);
-        scope.done();
-      });
-
-      test('Sends correct form parameters in request body', async () => {
-        const refreshToken = 'test-refresh-token';
-        const expectedResponse: WristbandTokenResponse = {
-          access_token: 'new-access-token',
-          refresh_token: 'new-refresh-token',
-          id_token: 'new-id-token',
-          expires_in: 3600,
-          token_type: 'bearer',
-        };
-        const expectedFormData = `grant_type=refresh_token&refresh_token=${refreshToken}`;
-
-        const scope = nock(`https://${DOMAIN}`)
-          .post('/api/v1/oauth2/token', expectedFormData)
-          .reply(200, expectedResponse);
-
-        const result = await wristbandService.refreshToken(refreshToken);
-        expect(result).toEqual(expectedResponse);
-        scope.done();
-      });
-    });
-
-    describe('revokeRefreshToken', () => {
-      test('With valid token succeeds', async () => {
-        const refreshToken = 'valid-refresh-token';
-
-        const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/revoke').reply(200);
-
-        await wristbandService.revokeRefreshToken(refreshToken);
-        scope.done();
-      });
-
-      test('Sends correct form parameters in request body', async () => {
-        const refreshToken = 'test-refresh-token';
-        const expectedFormData = `token=${refreshToken}`;
-
-        const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/revoke', expectedFormData).reply(200);
-
-        await wristbandService.revokeRefreshToken(refreshToken);
-        scope.done();
-      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': JSON_MEDIA_TYPE,
+            Accept: JSON_MEDIA_TYPE,
+          }),
+        })
+      );
     });
   });
 
-  describe('User Information', () => {
-    test('getUserInfo with valid token returns userinfo', async () => {
-      const accessToken = 'valid-access-token';
-      const userInfoResponse: WristbandUserinfoResponse = {
-        sub: 'user123',
-        app_id: 'devApp',
-        tnt_id: 'tenantA',
-        idp_name: 'wristband',
-        email: 'test@example.com',
-        email_verified: true,
-        name: 'Test User',
-      };
-      const userinfo: UserInfo = {
-        userId: 'user123',
-        applicationId: 'devApp',
-        tenantId: 'tenantA',
-        identityProviderName: 'wristband',
-        email: 'test@example.com',
-        emailVerified: true,
-        fullName: 'Test User',
-      };
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
-      const result = await wristbandService.getUserInfo(accessToken);
-      expect(result).toEqual(userinfo);
-      scope.done();
-    });
+  describe('getTokens', () => {
+    const code = 'valid-auth-code';
+    const redirectUri = 'https://app.example.com/callback';
+    const codeVerifier = 'valid-code-verifier';
+    const expectedResponse: WristbandTokenResponse = {
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      id_token: 'new-id-token',
+      expires_in: 3600,
+      token_type: 'bearer',
+    };
 
-    test('getUserInfo sends correct authorization header', async () => {
-      const accessToken = 'test-access-token';
-      const userInfoResponse: WristbandUserinfoResponse = {
-        sub: 'user123',
-        app_id: 'devApp',
-        tnt_id: 'tenantA',
-        idp_name: 'wristband',
-        email: 'test@example.com',
-        email_verified: true,
-        name: 'Test User',
-      };
-      const userinfo: UserInfo = {
-        userId: 'user123',
-        applicationId: 'devApp',
-        tenantId: 'tenantA',
-        identityProviderName: 'wristband',
-        email: 'test@example.com',
-        emailVerified: true,
-        fullName: 'Test User',
-      };
-      const scope = nock(`https://${DOMAIN}`)
-        .get('/api/v1/oauth2/userinfo')
-        .matchHeader('Authorization', `Bearer ${accessToken}`)
-        .matchHeader('Content-Type', /^application\/json/)
-        .matchHeader('Accept', /^application\/json/)
-        .reply(200, userInfoResponse);
-      const result = await wristbandService.getUserInfo(accessToken);
-      expect(result).toEqual(userinfo);
-      scope.done();
-    });
-  });
-
-  describe('Authentication', () => {
-    test('getTokens uses correct basic auth headers', async () => {
-      const code = 'test-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'test-verifier';
-
-      const expectedResponse: WristbandTokenResponse = {
-        access_token: 'access-token',
-        refresh_token: 'refresh-token',
-        id_token: 'id-token',
-        expires_in: 3600,
-        token_type: 'bearer',
-      };
-      const expectedAuth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
-
-      const scope = nock(`https://${DOMAIN}`)
-        .post('/api/v1/oauth2/token')
-        .matchHeader('Authorization', `Basic ${expectedAuth}`)
-        .reply(200, expectedResponse);
+    test('Returns token response on success', async () => {
+      mockFetch(200, expectedResponse);
 
       const result = await wristbandService.getTokens(code, redirectUri, codeVerifier);
+
       expect(result).toEqual(expectedResponse);
-      scope.done();
     });
 
-    test('refreshToken uses correct basic auth headers', async () => {
-      const refreshToken = 'test-refresh-token';
+    test('Sends correct form-encoded body', async () => {
+      mockFetch(200, expectedResponse);
 
-      const expectedResponse: WristbandTokenResponse = {
-        access_token: 'new-access-token',
-        refresh_token: 'new-refresh-token',
-        id_token: 'new-id-token',
-        expires_in: 3600,
-        token_type: 'bearer',
-      };
-      const expectedAuth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+      await wristbandService.getTokens(code, redirectUri, codeVerifier);
 
-      const scope = nock(`https://${DOMAIN}`)
-        .post('/api/v1/oauth2/token')
-        .matchHeader('Authorization', `Basic ${expectedAuth}`)
-        .reply(200, expectedResponse);
+      const expectedBody = [
+        'grant_type=authorization_code',
+        `code=${code}`,
+        `redirect_uri=${encodeURIComponent(redirectUri)}`,
+        `code_verifier=${encodeURIComponent(codeVerifier)}`,
+      ].join('&');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/oauth2/token`,
+        expect.objectContaining({ body: expectedBody })
+      );
+    });
+
+    test('Sends correct Basic auth header', async () => {
+      mockFetch(200, expectedResponse);
+
+      await wristbandService.getTokens(code, redirectUri, codeVerifier);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: EXPECTED_BASIC_AUTH }),
+        })
+      );
+    });
+
+    test('Throws InvalidGrantError on invalid_grant response', async () => {
+      mockFetch(400, { error: 'invalid_grant', error_description: 'Code expired' });
+
+      await expect(wristbandService.getTokens(code, redirectUri, codeVerifier)).rejects.toThrow(InvalidGrantError);
+    });
+
+    test('InvalidGrantError carries correct description', async () => {
+      mockFetch(400, { error: 'invalid_grant', error_description: 'Code expired' });
+
+      await expect(wristbandService.getTokens(code, redirectUri, codeVerifier)).rejects.toThrow('Code expired');
+    });
+
+    test('Rethrows non-invalid_grant FetchError', async () => {
+      mockFetch(500, { error: 'server_error' });
+
+      await expect(wristbandService.getTokens(code, redirectUri, codeVerifier)).rejects.toThrow(FetchError);
+    });
+
+    test('Throws when code is empty', async () => {
+      await expect(wristbandService.getTokens('', redirectUri, codeVerifier)).rejects.toThrow(
+        'Authorization code is required'
+      );
+    });
+
+    test('Throws when redirectUri is empty', async () => {
+      await expect(wristbandService.getTokens(code, '', codeVerifier)).rejects.toThrow('Redirect URI is required');
+    });
+
+    test('Throws when codeVerifier is empty', async () => {
+      await expect(wristbandService.getTokens(code, redirectUri, '')).rejects.toThrow('Code verifier is required');
+    });
+
+    test('Rethrows non-FetchError errors', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('Network failure'));
+      await expect(wristbandService.getTokens(code, redirectUri, codeVerifier)).rejects.toThrow('Network failure');
+    });
+  });
+
+  describe('getUserInfo', () => {
+    const accessToken = 'valid-access-token';
+    const userinfoResponse: WristbandUserinfoResponse = {
+      sub: 'user123',
+      app_id: 'devApp',
+      tnt_id: 'tenantA',
+      idp_name: 'wristband',
+      email: 'test@example.com',
+      email_verified: true,
+      name: 'Test User',
+    };
+    const expectedUserInfo: UserInfo = {
+      userId: 'user123',
+      applicationId: 'devApp',
+      tenantId: 'tenantA',
+      identityProviderName: 'wristband',
+      email: 'test@example.com',
+      emailVerified: true,
+      fullName: 'Test User',
+    };
+
+    test('Returns mapped UserInfo on success', async () => {
+      mockFetch(200, userinfoResponse);
+
+      const result = await wristbandService.getUserInfo(accessToken);
+
+      expect(result).toEqual(expectedUserInfo);
+    });
+
+    test('Sends correct Bearer auth header', async () => {
+      mockFetch(200, userinfoResponse);
+
+      await wristbandService.getUserInfo(accessToken);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/oauth2/userinfo`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': JSON_MEDIA_TYPE,
+            Accept: JSON_MEDIA_TYPE,
+          }),
+        })
+      );
+    });
+
+    test('Throws when accessToken is empty', async () => {
+      await expect(wristbandService.getUserInfo('')).rejects.toThrow('Access token is required');
+    });
+
+    test('Throws TypeError when userinfo response is invalid', async () => {
+      mockFetch(200, null);
+
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow(TypeError);
+    });
+
+    test('Throws TypeError when sub claim is missing', async () => {
+      mockFetch(200, { ...userinfoResponse, sub: undefined });
+
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow('missing sub claim');
+    });
+
+    test('Throws TypeError when tnt_id claim is missing', async () => {
+      mockFetch(200, { ...userinfoResponse, tnt_id: undefined });
+
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow('missing tnt_id claim');
+    });
+
+    test('Throws TypeError when app_id claim is missing', async () => {
+      mockFetch(200, { ...userinfoResponse, app_id: undefined });
+
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow('missing app_id claim');
+    });
+
+    test('Throws TypeError when idp_name claim is missing', async () => {
+      mockFetch(200, { ...userinfoResponse, idp_name: undefined });
+
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow('missing idp_name claim');
+    });
+  });
+
+  describe('refreshToken', () => {
+    const refreshToken = 'valid-refresh-token';
+    const expectedResponse: WristbandTokenResponse = {
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      id_token: 'new-id-token',
+      expires_in: 3600,
+      token_type: 'bearer',
+    };
+
+    test('Returns token response on success', async () => {
+      mockFetch(200, expectedResponse);
 
       const result = await wristbandService.refreshToken(refreshToken);
+
       expect(result).toEqual(expectedResponse);
-      scope.done();
     });
 
-    test('revokeRefreshToken uses correct basic auth headers', async () => {
-      const refreshToken = 'test-refresh-token';
-      const expectedAuth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+    test('Sends correct form-encoded body', async () => {
+      mockFetch(200, expectedResponse);
 
-      const scope = nock(`https://${DOMAIN}`)
-        .post('/api/v1/oauth2/revoke')
-        .matchHeader('Authorization', `Basic ${expectedAuth}`)
-        .reply(200);
+      await wristbandService.refreshToken(refreshToken);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/oauth2/token`,
+        expect.objectContaining({
+          body: `grant_type=refresh_token&refresh_token=${refreshToken}`,
+        })
+      );
+    });
+
+    test('Sends correct Basic auth header', async () => {
+      mockFetch(200, expectedResponse);
+
+      await wristbandService.refreshToken(refreshToken);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: EXPECTED_BASIC_AUTH }),
+        })
+      );
+    });
+
+    test('Throws InvalidGrantError on invalid_grant response', async () => {
+      mockFetch(400, { error: 'invalid_grant', error_description: 'Refresh token expired' });
+
+      await expect(wristbandService.refreshToken(refreshToken)).rejects.toThrow(InvalidGrantError);
+    });
+
+    test('InvalidGrantError carries correct description', async () => {
+      mockFetch(400, { error: 'invalid_grant', error_description: 'Refresh token expired' });
+
+      await expect(wristbandService.refreshToken(refreshToken)).rejects.toThrow('Refresh token expired');
+    });
+
+    test('Rethrows non-invalid_grant FetchError', async () => {
+      mockFetch(500, { error: 'server_error' });
+
+      await expect(wristbandService.refreshToken(refreshToken)).rejects.toThrow(FetchError);
+    });
+
+    test('Throws when refreshToken is empty', async () => {
+      await expect(wristbandService.refreshToken('')).rejects.toThrow('Refresh token is required');
+    });
+  });
+
+  describe('revokeRefreshToken', () => {
+    const refreshToken = 'valid-refresh-token';
+
+    test('Resolves successfully on 200', async () => {
+      mockFetch(200, '');
+
+      await expect(wristbandService.revokeRefreshToken(refreshToken)).resolves.toBeUndefined();
+    });
+
+    test('Sends correct form-encoded body', async () => {
+      mockFetch(200, '');
 
       await wristbandService.revokeRefreshToken(refreshToken);
-      scope.done();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/oauth2/revoke`,
+        expect.objectContaining({ body: `token=${refreshToken}` })
+      );
+    });
+
+    test('Sends correct Basic auth header', async () => {
+      mockFetch(200, '');
+
+      await wristbandService.revokeRefreshToken(refreshToken);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: EXPECTED_BASIC_AUTH }),
+        })
+      );
+    });
+
+    test('Throws FetchError on error response', async () => {
+      mockFetch(400, { error: 'bad_request' });
+
+      await expect(wristbandService.revokeRefreshToken(refreshToken)).rejects.toThrow(FetchError);
+    });
+
+    test('Throws when refreshToken is empty', async () => {
+      await expect(wristbandService.revokeRefreshToken('')).rejects.toThrow('Refresh token is required');
     });
   });
 });

--- a/test/wristband-service/error.test.ts
+++ b/test/wristband-service/error.test.ts
@@ -1,679 +1,299 @@
-/* eslint-disable no-new */
-/* eslint-disable no-restricted-syntax */
-/* eslint-disable no-await-in-loop */
-
-import nock from 'nock';
 import { WristbandService } from '../../src/wristband-service';
+import { FetchError } from '../../src/error/fetch-error';
 import { InvalidGrantError } from '../../src/error';
 
 const DOMAIN = 'your-wristband-domain';
 const CLIENT_ID = 'test-client-id';
 const CLIENT_SECRET = 'test-client-secret';
 
+function mockFetch(status: number, body: unknown) {
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return 'application/json';
+      },
+    },
+    text: jest.fn().mockResolvedValue(bodyText),
+  });
+}
+
 describe('WristbandService - Error Handling', () => {
   let wristbandService: WristbandService;
 
   beforeEach(() => {
-    // Clean up any previous nock interceptors
-    nock.cleanAll();
-
-    // Create service instance
     wristbandService = new WristbandService(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('Constructor Validation', () => {
     test('With empty domain throws error', () => {
-      try {
-        new WristbandService('', CLIENT_ID, CLIENT_SECRET);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Wristband application domain is required');
-      }
+      expect(() => {
+        return new WristbandService('', CLIENT_ID, CLIENT_SECRET);
+      }).toThrow('Wristband application domain is required');
     });
 
     test('With null domain throws error', () => {
-      try {
-        new WristbandService(null as any, CLIENT_ID, CLIENT_SECRET);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Wristband application domain is required');
-      }
+      expect(() => {
+        return new WristbandService(null as any, CLIENT_ID, CLIENT_SECRET);
+      }).toThrow('Wristband application domain is required');
     });
 
     test('With whitespace-only domain throws error', () => {
-      try {
-        new WristbandService('   ', CLIENT_ID, CLIENT_SECRET);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Wristband application domain is required');
-      }
+      expect(() => {
+        return new WristbandService('   ', CLIENT_ID, CLIENT_SECRET);
+      }).toThrow('Wristband application domain is required');
     });
 
     test('With empty client ID throws error', () => {
-      try {
-        new WristbandService(DOMAIN, '', CLIENT_SECRET);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Client ID is required');
-      }
+      expect(() => {
+        return new WristbandService(DOMAIN, '', CLIENT_SECRET);
+      }).toThrow('Client ID is required');
     });
 
     test('With null client ID throws error', () => {
-      try {
-        new WristbandService(DOMAIN, null as any, CLIENT_SECRET);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Client ID is required');
-      }
+      expect(() => {
+        return new WristbandService(DOMAIN, null as any, CLIENT_SECRET);
+      }).toThrow('Client ID is required');
     });
 
     test('With whitespace-only client ID throws error', () => {
-      try {
-        new WristbandService(DOMAIN, '   ', CLIENT_SECRET);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Client ID is required');
-      }
+      expect(() => {
+        return new WristbandService(DOMAIN, '   ', CLIENT_SECRET);
+      }).toThrow('Client ID is required');
     });
 
     test('With empty client secret throws error', () => {
-      try {
-        new WristbandService(DOMAIN, CLIENT_ID, '');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Client secret is required');
-      }
+      expect(() => {
+        return new WristbandService(DOMAIN, CLIENT_ID, '');
+      }).toThrow('Client secret is required');
     });
 
     test('With null client secret throws error', () => {
-      try {
-        new WristbandService(DOMAIN, CLIENT_ID, null as any);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Client secret is required');
-      }
+      expect(() => {
+        return new WristbandService(DOMAIN, CLIENT_ID, null as any);
+      }).toThrow('Client secret is required');
     });
 
     test('With whitespace-only client secret throws error', () => {
-      try {
-        new WristbandService(DOMAIN, CLIENT_ID, '   ');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Client secret is required');
-      }
+      expect(() => {
+        return new WristbandService(DOMAIN, CLIENT_ID, '   ');
+      }).toThrow('Client secret is required');
     });
   });
 
   describe('Parameter Validation', () => {
     test('getTokens with empty code throws error', async () => {
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-
-      try {
-        await wristbandService.getTokens('', redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Authorization code is required');
-      }
+      await expect(wristbandService.getTokens('', 'https://app.example.com/callback', 'verifier')).rejects.toThrow(
+        'Authorization code is required'
+      );
     });
 
     test('getTokens with null code throws error', async () => {
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-
-      try {
-        await wristbandService.getTokens(null as any, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Authorization code is required');
-      }
+      await expect(
+        wristbandService.getTokens(null as any, 'https://app.example.com/callback', 'verifier')
+      ).rejects.toThrow('Authorization code is required');
     });
 
     test('getTokens with whitespace-only code throws error', async () => {
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-
-      try {
-        await wristbandService.getTokens('   ', redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Authorization code is required');
-      }
+      await expect(wristbandService.getTokens('   ', 'https://app.example.com/callback', 'verifier')).rejects.toThrow(
+        'Authorization code is required'
+      );
     });
 
     test('getTokens with empty redirect URI throws error', async () => {
-      const code = 'valid-auth-code';
-      const codeVerifier = 'valid-code-verifier';
-
-      try {
-        await wristbandService.getTokens(code, '', codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Redirect URI is required');
-      }
+      await expect(wristbandService.getTokens('code', '', 'verifier')).rejects.toThrow('Redirect URI is required');
     });
 
     test('getTokens with null redirect URI throws error', async () => {
-      const code = 'valid-auth-code';
-      const codeVerifier = 'valid-code-verifier';
-
-      try {
-        await wristbandService.getTokens(code, null as any, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Redirect URI is required');
-      }
+      await expect(wristbandService.getTokens('code', null as any, 'verifier')).rejects.toThrow(
+        'Redirect URI is required'
+      );
     });
 
     test('getTokens with whitespace-only redirect URI throws error', async () => {
-      const code = 'valid-auth-code';
-      const codeVerifier = 'valid-code-verifier';
-
-      try {
-        await wristbandService.getTokens(code, '   ', codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Redirect URI is required');
-      }
+      await expect(wristbandService.getTokens('code', '   ', 'verifier')).rejects.toThrow('Redirect URI is required');
     });
 
     test('getTokens with empty code verifier throws error', async () => {
-      const code = 'valid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, '');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Code verifier is required');
-      }
+      await expect(wristbandService.getTokens('code', 'https://app.example.com/callback', '')).rejects.toThrow(
+        'Code verifier is required'
+      );
     });
 
     test('getTokens with null code verifier throws error', async () => {
-      const code = 'valid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, null as any);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Code verifier is required');
-      }
+      await expect(wristbandService.getTokens('code', 'https://app.example.com/callback', null as any)).rejects.toThrow(
+        'Code verifier is required'
+      );
     });
 
     test('getTokens with whitespace-only code verifier throws error', async () => {
-      const code = 'valid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, '   ');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Code verifier is required');
-      }
+      await expect(wristbandService.getTokens('code', 'https://app.example.com/callback', '   ')).rejects.toThrow(
+        'Code verifier is required'
+      );
     });
 
     test('refreshToken with empty refresh token throws error', async () => {
-      try {
-        await wristbandService.refreshToken('');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Refresh token is required');
-      }
+      await expect(wristbandService.refreshToken('')).rejects.toThrow('Refresh token is required');
     });
 
     test('refreshToken with null refresh token throws error', async () => {
-      try {
-        await wristbandService.refreshToken(null as any);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Refresh token is required');
-      }
+      await expect(wristbandService.refreshToken(null as any)).rejects.toThrow('Refresh token is required');
     });
 
     test('refreshToken with whitespace-only refresh token throws error', async () => {
-      try {
-        await wristbandService.refreshToken('   ');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Refresh token is required');
-      }
+      await expect(wristbandService.refreshToken('   ')).rejects.toThrow('Refresh token is required');
     });
 
     test('getUserInfo with empty access token throws error', async () => {
-      try {
-        await wristbandService.getUserInfo('');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Access token is required');
-      }
+      await expect(wristbandService.getUserInfo('')).rejects.toThrow('Access token is required');
     });
 
     test('getUserInfo with null access token throws error', async () => {
-      try {
-        await wristbandService.getUserInfo(null as any);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Access token is required');
-      }
+      await expect(wristbandService.getUserInfo(null as any)).rejects.toThrow('Access token is required');
     });
 
     test('getUserInfo with whitespace-only access token throws error', async () => {
-      try {
-        await wristbandService.getUserInfo('   ');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Access token is required');
-      }
+      await expect(wristbandService.getUserInfo('   ')).rejects.toThrow('Access token is required');
     });
 
     test('revokeRefreshToken with empty refresh token throws error', async () => {
-      try {
-        await wristbandService.revokeRefreshToken('');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Refresh token is required');
-      }
+      await expect(wristbandService.revokeRefreshToken('')).rejects.toThrow('Refresh token is required');
     });
 
     test('revokeRefreshToken with null refresh token throws error', async () => {
-      try {
-        await wristbandService.revokeRefreshToken(null as any);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Refresh token is required');
-      }
+      await expect(wristbandService.revokeRefreshToken(null as any)).rejects.toThrow('Refresh token is required');
     });
 
     test('revokeRefreshToken with whitespace-only refresh token throws error', async () => {
-      try {
-        await wristbandService.revokeRefreshToken('   ');
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Refresh token is required');
-      }
-    });
-  });
-
-  describe('Token Response Validation', () => {
-    test('getTokens with invalid token response (missing access_token) throws error', async () => {
-      const code = 'valid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-
-      const invalidResponse = {
-        refresh_token: 'refresh-token',
-        expires_in: 3600,
-        token_type: 'bearer',
-        // missing access_token
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid token response: missing access_token');
-      }
-
-      scope.done();
-    });
-
-    test('getTokens with invalid token response (missing expires_in) throws error', async () => {
-      const code = 'valid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-      const invalidResponse = {
-        access_token: 'access-token',
-        refresh_token: 'refresh-token',
-        token_type: 'bearer',
-        // missing expires_in
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid token response: missing expires_in');
-      }
-
-      scope.done();
-    });
-
-    test('getTokens with invalid token response (non-object) throws error', async () => {
-      const code = 'valid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-      const invalidResponse = 'not an object';
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid token response');
-      }
-
-      scope.done();
-    });
-
-    test('refreshToken with invalid token response (missing access_token) throws error', async () => {
-      const refreshToken = 'valid-refresh-token';
-      const invalidResponse = {
-        refresh_token: 'new-refresh-token',
-        expires_in: 3600,
-        token_type: 'bearer',
-        // missing access_token
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.refreshToken(refreshToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid token response: missing access_token');
-      }
-
-      scope.done();
-    });
-
-    test('refreshToken with invalid token response (missing expires_in) throws error', async () => {
-      const refreshToken = 'valid-refresh-token';
-      const invalidResponse = {
-        access_token: 'new-access-token',
-        refresh_token: 'new-refresh-token',
-        token_type: 'bearer',
-        // missing expires_in
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.refreshToken(refreshToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid token response: missing expires_in');
-      }
-
-      scope.done();
+      await expect(wristbandService.revokeRefreshToken('   ')).rejects.toThrow('Refresh token is required');
     });
   });
 
   describe('UserInfo Response Validation', () => {
-    test('getUserInfo with invalid response (non-object) throws error', async () => {
-      const accessToken = 'valid-access-token';
-      const invalidResponse = 'not an object';
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid userinfo response: expected object');
-      }
-
-      scope.done();
+    test('getUserInfo with non-object response throws TypeError', async () => {
+      mockFetch(200, 42);
+      await expect(wristbandService.getUserInfo('valid-access-token')).rejects.toThrow(
+        'Invalid userinfo response: expected object'
+      );
     });
 
-    test('getUserInfo with null response throws error', async () => {
-      const accessToken = 'valid-access-token';
-      // @ts-ignore
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, null);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe('Invalid userinfo response: expected object');
-      }
-
-      scope.done();
+    test('getUserInfo with null response throws TypeError', async () => {
+      mockFetch(200, null);
+      await expect(wristbandService.getUserInfo('valid-access-token')).rejects.toThrow(
+        'Invalid userinfo response: expected object'
+      );
     });
   });
 
   describe('SDK Configuration Error Handling', () => {
-    test('getSdkConfiguration with network error throws error', async () => {
-      const scope = nock(`https://${DOMAIN}`)
-        .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-        .reply(500, { error: 'Internal Server Error' });
-
-      try {
-        await wristbandService.getSdkConfiguration();
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
-
-      scope.done();
+    test('getSdkConfiguration with 500 response throws FetchError', async () => {
+      mockFetch(500, { error: 'Internal Server Error' });
+      await expect(wristbandService.getSdkConfiguration()).rejects.toThrow(FetchError);
     });
 
-    test('getSdkConfiguration with 404 error throws error', async () => {
-      const scope = nock(`https://${DOMAIN}`)
-        .get(`/api/v1/clients/${CLIENT_ID}/sdk-configuration`)
-        .reply(404, { error: 'Client not found' });
-
-      try {
-        await wristbandService.getSdkConfiguration();
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
-
-      scope.done();
+    test('getSdkConfiguration with 404 response throws FetchError', async () => {
+      mockFetch(404, { error: 'Client not found' });
+      await expect(wristbandService.getSdkConfiguration()).rejects.toThrow(FetchError);
     });
   });
 
   describe('API Error Handling', () => {
-    test('getTokens with invalid grant error throws InvalidGrantError', async () => {
-      const code = 'invalid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
+    test('getTokens with invalid_grant throws InvalidGrantError', async () => {
       const errorResponse = {
         error: 'invalid_grant',
         error_description: 'The authorization code is invalid or has expired',
       };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(400, errorResponse);
+      mockFetch(400, errorResponse);
 
-      try {
-        await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(InvalidGrantError);
-        expect((error as InvalidGrantError).code).toBe('invalid_grant');
-        expect((error as InvalidGrantError).errorDescription).toBe(errorResponse.error_description);
-      }
-
-      scope.done();
+      const error = await wristbandService
+        .getTokens('invalid-code', 'https://app.example.com/callback', 'verifier')
+        .catch((e) => {
+          return e;
+        });
+      expect(error).toBeInstanceOf(InvalidGrantError);
+      expect(error.code).toBe('invalid_grant');
+      expect(error.errorDescription).toBe(errorResponse.error_description);
     });
 
-    test('getTokens with invalid grant error (no description) throws InvalidGrantError with default message', async () => {
-      const code = 'invalid-auth-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-      const errorResponse = {
-        error: 'invalid_grant',
-        // no error_description
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(400, errorResponse);
+    test('getTokens with invalid_grant and no description uses default message', async () => {
+      mockFetch(400, { error: 'invalid_grant' });
 
-      try {
-        await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(InvalidGrantError);
-        expect((error as InvalidGrantError).code).toBe('invalid_grant');
-        expect((error as InvalidGrantError).errorDescription).toBe('Invalid grant');
-      }
-
-      scope.done();
+      const error = await wristbandService
+        .getTokens('invalid-code', 'https://app.example.com/callback', 'verifier')
+        .catch((e) => {
+          return e;
+        });
+      expect(error).toBeInstanceOf(InvalidGrantError);
+      expect(error.errorDescription).toBe('Invalid grant');
     });
 
-    test('refreshToken with invalid token throws InvalidGrantError', async () => {
-      const refreshToken = 'invalid-refresh-token';
+    test('getTokens with non-invalid_grant error rethrows FetchError', async () => {
+      mockFetch(400, { error: 'unsupported_grant_type', error_description: 'Grant type not supported' });
+      await expect(wristbandService.getTokens('code', 'https://app.example.com/callback', 'verifier')).rejects.toThrow(
+        FetchError
+      );
+    });
+
+    test('refreshToken with invalid_grant throws InvalidGrantError', async () => {
       const errorResponse = {
         error: 'invalid_grant',
         error_description: 'The refresh token is invalid or has expired',
       };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(400, errorResponse);
+      mockFetch(400, errorResponse);
 
-      try {
-        await wristbandService.refreshToken(refreshToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(InvalidGrantError);
-        expect((error as InvalidGrantError).code).toBe('invalid_grant');
-        expect((error as InvalidGrantError).errorDescription).toBe(errorResponse.error_description);
-      }
-
-      scope.done();
+      const error = await wristbandService.refreshToken('invalid-refresh-token').catch((e) => {
+        return e;
+      });
+      expect(error).toBeInstanceOf(InvalidGrantError);
+      expect(error.code).toBe('invalid_grant');
+      expect(error.errorDescription).toBe(errorResponse.error_description);
     });
 
-    test('refreshToken with invalid grant error (no description) throws InvalidGrantError with default message', async () => {
-      const refreshToken = 'invalid-refresh-token';
-      const errorResponse = {
-        error: 'invalid_grant',
-        // no error_description
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(400, errorResponse);
+    test('refreshToken with invalid_grant and no description uses default message', async () => {
+      mockFetch(400, { error: 'invalid_grant' });
 
-      try {
-        await wristbandService.refreshToken(refreshToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(InvalidGrantError);
-        expect((error as InvalidGrantError).code).toBe('invalid_grant');
-        expect((error as InvalidGrantError).errorDescription).toBe('Invalid refresh token');
-      }
-
-      scope.done();
+      const error = await wristbandService.refreshToken('invalid-refresh-token').catch((e) => {
+        return e;
+      });
+      expect(error).toBeInstanceOf(InvalidGrantError);
+      expect(error.errorDescription).toBe('Invalid refresh token');
     });
 
-    test('getTokens with other API error throws original error', async () => {
-      const code = 'valid-code';
-      const redirectUri = 'https://app.example.com/callback';
-      const codeVerifier = 'valid-code-verifier';
-      const errorResponse = {
-        error: 'unsupported_grant_type',
-        error_description: 'Grant type not supported',
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/token').reply(400, errorResponse);
-
-      try {
-        await wristbandService.getTokens(code, redirectUri, codeVerifier);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).not.toBeInstanceOf(InvalidGrantError);
-        expect(error).toBeInstanceOf(Error);
-      }
-
-      scope.done();
+    test('getTokens with other API error rethrows FetchError', async () => {
+      mockFetch(400, { error: 'unsupported_grant_type' });
+      await expect(
+        wristbandService.getTokens('code', 'https://app.example.com/callback', 'verifier')
+      ).rejects.not.toThrow(InvalidGrantError);
     });
 
-    test('getUserInfo with invalid token throws error', async () => {
-      const accessToken = 'invalid-access-token';
-      const errorResponse = {
-        error: 'invalid_token',
-        error_description: 'The access token is invalid or has expired',
-      };
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(401, errorResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
-
-      scope.done();
+    test('getUserInfo with 401 response throws FetchError', async () => {
+      mockFetch(401, { error: 'invalid_token', error_description: 'The access token is invalid or has expired' });
+      await expect(wristbandService.getUserInfo('invalid-access-token')).rejects.toThrow(FetchError);
     });
 
-    test('getUserInfo with forbidden response (403) throws error', async () => {
-      const accessToken = 'valid-access-token';
-      const errorResponse = {
-        error: 'forbidden',
-        error_description: 'Insufficient permissions',
-      };
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(403, errorResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
-
-      scope.done();
+    test('getUserInfo with 403 response throws FetchError', async () => {
+      mockFetch(403, { error: 'forbidden', error_description: 'Insufficient permissions' });
+      await expect(wristbandService.getUserInfo('valid-access-token')).rejects.toThrow(FetchError);
     });
 
-    test('revokeRefreshToken with error throws original error', async () => {
-      const refreshToken = 'valid-refresh-token';
-      const errorResponse = {
-        error: 'server_error',
-        error_description: 'Internal server error',
-      };
-      const scope = nock(`https://${DOMAIN}`).post('/api/v1/oauth2/revoke').reply(500, errorResponse);
-
-      try {
-        await wristbandService.revokeRefreshToken(refreshToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
-
-      scope.done();
+    test('revokeRefreshToken with 500 response throws FetchError', async () => {
+      mockFetch(500, { error: 'server_error', error_description: 'Internal server error' });
+      await expect(wristbandService.revokeRefreshToken('valid-refresh-token')).rejects.toThrow(FetchError);
     });
 
-    test('Different HTTP status codes are handled appropriately', async () => {
-      const accessToken = 'valid-access-token';
-      const statusCodes = [400, 401, 403, 404, 500];
-
-      for (const status of statusCodes) {
-        const errorResponse = { error: 'error', error_description: `Error with status ${status}` };
-        const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(status, errorResponse);
-
-        try {
-          await wristbandService.getUserInfo(accessToken);
-          fail(`Expected an error to be thrown for status ${status}`);
-        } catch (error) {
-          expect(error).toBeInstanceOf(Error);
-        }
-
-        scope.done();
-      }
+    test('Different HTTP status codes all throw FetchError', async () => {
+      await Promise.all(
+        [400, 401, 403, 404, 500].map((status) => {
+          mockFetch(status, { error: 'error', error_description: `Error with status ${status}` });
+          return expect(wristbandService.getUserInfo('valid-access-token')).rejects.toThrow(FetchError);
+        })
+      );
     });
   });
 });

--- a/test/wristband-service/map-userinfo.test.ts
+++ b/test/wristband-service/map-userinfo.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import { WristbandService } from '../../src/wristband-service';
 import { WristbandUserinfoResponse } from '../../src/types';
 
@@ -7,12 +5,29 @@ const DOMAIN = 'your-wristband-domain';
 const CLIENT_ID = 'test-client-id';
 const CLIENT_SECRET = 'test-client-secret';
 
+function mockFetch(status: number, body: unknown) {
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
+  global.fetch = jest.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: () => {
+        return 'application/json';
+      },
+    },
+    text: jest.fn().mockResolvedValue(bodyText),
+  });
+}
+
 describe('WristbandService - UserInfo Claims Mapping', () => {
   let wristbandService: WristbandService;
 
   beforeEach(() => {
-    nock.cleanAll();
     wristbandService = new WristbandService(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('Required Claims (Always Present)', () => {
@@ -24,8 +39,7 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         app_id: 'app-789',
         idp_name: 'wristband',
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -33,10 +47,9 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.tenantId).toBe('tenant-456');
       expect(result.applicationId).toBe('app-789');
       expect(result.identityProviderName).toBe('wristband');
-      scope.done();
     });
 
-    test('Required claims are always mapped from snake_case to camelCase', async () => {
+    test('Converts snake_case required claims to camelCase', async () => {
       const accessToken = 'valid-access-token';
       const userInfoResponse: WristbandUserinfoResponse = {
         sub: 'user-abc',
@@ -44,24 +57,18 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         app_id: 'app-def',
         idp_name: 'google',
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
-      // Verify snake_case is converted to camelCase
       expect(result).toHaveProperty('userId', 'user-abc');
       expect(result).toHaveProperty('tenantId', 'tenant-xyz');
       expect(result).toHaveProperty('applicationId', 'app-def');
       expect(result).toHaveProperty('identityProviderName', 'google');
-
-      // Ensure snake_case properties don't exist in result
       expect(result).not.toHaveProperty('sub');
       expect(result).not.toHaveProperty('tnt_id');
       expect(result).not.toHaveProperty('app_id');
       expect(result).not.toHaveProperty('idp_name');
-
-      scope.done();
     });
   });
 
@@ -86,8 +93,7 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         locale: 'en-US',
         updated_at: 1672531200,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -103,7 +109,6 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.timeZone).toBe('America/New_York');
       expect(result.locale).toBe('en-US');
       expect(result.updatedAt).toBe(1672531200);
-      scope.done();
     });
 
     test('Profile claims are undefined when not present', async () => {
@@ -113,10 +118,8 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // No profile scope claims
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -132,7 +135,6 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.timeZone).toBeUndefined();
       expect(result.locale).toBeUndefined();
       expect(result.updatedAt).toBeUndefined();
-      scope.done();
     });
 
     test('Maps partial profile scope claims', async () => {
@@ -145,10 +147,8 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         name: 'Jane Smith',
         given_name: 'Jane',
         locale: 'fr-FR',
-        // Other profile claims missing
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -158,7 +158,6 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.familyName).toBeUndefined();
       expect(result.middleName).toBeUndefined();
       expect(result.nickname).toBeUndefined();
-      scope.done();
     });
 
     test('Converts profile snake_case claims to camelCase', async () => {
@@ -174,8 +173,7 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         preferred_username: 'aliceb',
         updated_at: 1672531200,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -184,15 +182,11 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.middleName).toBe('Marie');
       expect(result.displayName).toBe('aliceb');
       expect(result.updatedAt).toBe(1672531200);
-
-      // Verify snake_case doesn't exist
       expect(result).not.toHaveProperty('given_name');
       expect(result).not.toHaveProperty('family_name');
       expect(result).not.toHaveProperty('middle_name');
       expect(result).not.toHaveProperty('preferred_username');
       expect(result).not.toHaveProperty('updated_at');
-
-      scope.done();
     });
   });
 
@@ -207,14 +201,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         email: 'user@example.com',
         email_verified: true,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.email).toBe('user@example.com');
       expect(result.emailVerified).toBe(true);
-      scope.done();
     });
 
     test('Email claims are undefined when not present', async () => {
@@ -224,16 +216,13 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // No email scope claims
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.email).toBeUndefined();
       expect(result.emailVerified).toBeUndefined();
-      scope.done();
     });
 
     test('Maps email with emailVerified false', async () => {
@@ -246,14 +235,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         email: 'unverified@example.com',
         email_verified: false,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.email).toBe('unverified@example.com');
       expect(result.emailVerified).toBe(false);
-      scope.done();
     });
 
     test('Converts email_verified to emailVerified', async () => {
@@ -266,14 +253,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         email: 'test@example.com',
         email_verified: true,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.emailVerified).toBe(true);
       expect(result).not.toHaveProperty('email_verified');
-      scope.done();
     });
   });
 
@@ -288,14 +273,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         phone_number: '+1234567890',
         phone_number_verified: true,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.phoneNumber).toBe('+1234567890');
       expect(result.phoneNumberVerified).toBe(true);
-      scope.done();
     });
 
     test('Phone claims are undefined when not present', async () => {
@@ -305,16 +288,13 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // No phone scope claims
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.phoneNumber).toBeUndefined();
       expect(result.phoneNumberVerified).toBeUndefined();
-      scope.done();
     });
 
     test('Maps phone with phoneNumberVerified false', async () => {
@@ -327,14 +307,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         phone_number: '+9876543210',
         phone_number_verified: false,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.phoneNumber).toBe('+9876543210');
       expect(result.phoneNumberVerified).toBe(false);
-      scope.done();
     });
 
     test('Converts phone_number and phone_number_verified to camelCase', async () => {
@@ -347,8 +325,7 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         phone_number: '+1122334455',
         phone_number_verified: true,
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -356,7 +333,6 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.phoneNumberVerified).toBe(true);
       expect(result).not.toHaveProperty('phone_number');
       expect(result).not.toHaveProperty('phone_number_verified');
-      scope.done();
     });
   });
 
@@ -369,36 +345,18 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         app_id: 'app-789',
         idp_name: 'wristband',
         roles: [
-          {
-            id: 'role-1',
-            name: 'app:myapp:admin',
-            display_name: 'Admin Role',
-          },
-          {
-            id: 'role-2',
-            name: 'app:myapp:user',
-            display_name: 'User Role',
-          },
+          { id: 'role-1', name: 'app:myapp:admin', display_name: 'Admin Role' },
+          { id: 'role-2', name: 'app:myapp:user', display_name: 'User Role' },
         ],
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.roles).toBeDefined();
       expect(result.roles).toHaveLength(2);
-      expect(result.roles![0]).toEqual({
-        id: 'role-1',
-        name: 'app:myapp:admin',
-        displayName: 'Admin Role',
-      });
-      expect(result.roles![1]).toEqual({
-        id: 'role-2',
-        name: 'app:myapp:user',
-        displayName: 'User Role',
-      });
-      scope.done();
+      expect(result.roles![0]).toEqual({ id: 'role-1', name: 'app:myapp:admin', displayName: 'Admin Role' });
+      expect(result.roles![1]).toEqual({ id: 'role-2', name: 'app:myapp:user', displayName: 'User Role' });
     });
 
     test('Roles are undefined when not present', async () => {
@@ -408,15 +366,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // No roles scope claims
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.roles).toBeUndefined();
-      scope.done();
     });
 
     test('Maps empty roles array', async () => {
@@ -428,14 +383,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         idp_name: 'wristband',
         roles: [],
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.roles).toBeDefined();
       expect(result.roles).toHaveLength(0);
-      scope.done();
     });
 
     test('Converts role display_name to displayName', async () => {
@@ -445,22 +398,14 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        roles: [
-          {
-            id: 'role-1',
-            name: 'app:myapp:superadmin',
-            display_name: 'Super Admin',
-          },
-        ],
+        roles: [{ id: 'role-1', name: 'app:myapp:superadmin', display_name: 'Super Admin' }],
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.roles![0].displayName).toBe('Super Admin');
       expect(result.roles![0]).not.toHaveProperty('display_name');
-      scope.done();
     });
 
     test('Handles role with displayName instead of display_name', async () => {
@@ -470,24 +415,16 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        roles: [
-          {
-            id: 'role-1',
-            name: 'app:myapp:editor',
-            displayName: 'Editor Role', // Already camelCase
-          },
-        ],
+        roles: [{ id: 'role-1', name: 'app:myapp:editor', displayName: 'Editor Role' }],
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.roles![0].displayName).toBe('Editor Role');
-      scope.done();
     });
 
-    test('Maps multiple roles with different formats', async () => {
+    test('Maps multiple roles with mixed display_name formats', async () => {
       const accessToken = 'valid-access-token';
       const userInfoResponse: WristbandUserinfoResponse = {
         sub: 'user-123',
@@ -495,27 +432,17 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         app_id: 'app-789',
         idp_name: 'wristband',
         roles: [
-          {
-            id: 'role-1',
-            name: 'app:myapp:admin',
-            display_name: 'Admin',
-          },
-          {
-            id: 'role-2',
-            name: 'app:myapp:user',
-            displayName: 'User', // Already camelCase
-          },
+          { id: 'role-1', name: 'app:myapp:admin', display_name: 'Admin' },
+          { id: 'role-2', name: 'app:myapp:user', displayName: 'User' },
         ],
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.roles).toHaveLength(2);
       expect(result.roles![0].displayName).toBe('Admin');
       expect(result.roles![1].displayName).toBe('User');
-      scope.done();
     });
   });
 
@@ -533,8 +460,7 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
           level: 5,
         },
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -544,7 +470,6 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         employeeId: 'EMP-001',
         level: 5,
       });
-      scope.done();
     });
 
     test('Custom claims are undefined when not present', async () => {
@@ -554,15 +479,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // No custom claims
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.customClaims).toBeUndefined();
-      scope.done();
     });
 
     test('Maps empty custom claims object', async () => {
@@ -574,14 +496,12 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         idp_name: 'wristband',
         custom_claims: {},
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
       expect(result.customClaims).toBeDefined();
       expect(result.customClaims).toEqual({});
-      scope.done();
     });
 
     test('Maps custom claims with various data types', async () => {
@@ -599,8 +519,7 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
           objectField: { nested: 'data' },
         },
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
@@ -611,7 +530,6 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         arrayField: ['item1', 'item2'],
         objectField: { nested: 'data' },
       });
-      scope.done();
     });
   });
 
@@ -619,12 +537,10 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
     test('Maps complete userinfo with all scope claims present', async () => {
       const accessToken = 'valid-access-token';
       const userInfoResponse: WristbandUserinfoResponse = {
-        // Required claims
         sub: 'user-full-123',
         tnt_id: 'tenant-full-456',
         app_id: 'app-full-789',
         idp_name: 'okta',
-        // Profile scope
         name: 'Alice Marie Johnson',
         given_name: 'Alice',
         family_name: 'Johnson',
@@ -637,42 +553,24 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         zoneinfo: 'Europe/London',
         locale: 'en-GB',
         updated_at: 1672531200,
-        // Email scope
         email: 'alice@example.com',
         email_verified: true,
-        // Phone scope
         phone_number: '+447123456789',
         phone_number_verified: true,
-        // Roles scope
         roles: [
-          {
-            id: 'role-admin',
-            name: 'app:myapp:admin',
-            display_name: 'Administrator',
-          },
-          {
-            id: 'role-editor',
-            name: 'app:myapp:editor',
-            display_name: 'Editor',
-          },
+          { id: 'role-admin', name: 'app:myapp:admin', display_name: 'Administrator' },
+          { id: 'role-editor', name: 'app:myapp:editor', display_name: 'Editor' },
         ],
-        // Custom claims
-        custom_claims: {
-          department: 'Product',
-          location: 'London',
-        },
+        custom_claims: { department: 'Product', location: 'London' },
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
-      // Required claims
       expect(result.userId).toBe('user-full-123');
       expect(result.tenantId).toBe('tenant-full-456');
       expect(result.applicationId).toBe('app-full-789');
       expect(result.identityProviderName).toBe('okta');
-      // Profile claims
       expect(result.fullName).toBe('Alice Marie Johnson');
       expect(result.givenName).toBe('Alice');
       expect(result.familyName).toBe('Johnson');
@@ -685,31 +583,14 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
       expect(result.timeZone).toBe('Europe/London');
       expect(result.locale).toBe('en-GB');
       expect(result.updatedAt).toBe(1672531200);
-      // Email claims
       expect(result.email).toBe('alice@example.com');
       expect(result.emailVerified).toBe(true);
-      // Phone claims
       expect(result.phoneNumber).toBe('+447123456789');
       expect(result.phoneNumberVerified).toBe(true);
-      // Roles
       expect(result.roles).toHaveLength(2);
-      expect(result.roles![0]).toEqual({
-        id: 'role-admin',
-        name: 'app:myapp:admin',
-        displayName: 'Administrator',
-      });
-      expect(result.roles![1]).toEqual({
-        id: 'role-editor',
-        name: 'app:myapp:editor',
-        displayName: 'Editor',
-      });
-      // Custom claims
-      expect(result.customClaims).toEqual({
-        department: 'Product',
-        location: 'London',
-      });
-
-      scope.done();
+      expect(result.roles![0]).toEqual({ id: 'role-admin', name: 'app:myapp:admin', displayName: 'Administrator' });
+      expect(result.roles![1]).toEqual({ id: 'role-editor', name: 'app:myapp:editor', displayName: 'Editor' });
+      expect(result.customClaims).toEqual({ department: 'Product', location: 'London' });
     });
 
     test('Maps minimal userinfo with only required claims', async () => {
@@ -720,137 +601,92 @@ describe('WristbandService - UserInfo Claims Mapping', () => {
         app_id: 'app-minimal',
         idp_name: 'wristband',
       };
-
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, userInfoResponse);
+      mockFetch(200, userInfoResponse);
 
       const result = await wristbandService.getUserInfo(accessToken);
 
-      // Required claims present
       expect(result.userId).toBe('user-minimal');
       expect(result.tenantId).toBe('tenant-minimal');
       expect(result.applicationId).toBe('app-minimal');
       expect(result.identityProviderName).toBe('wristband');
-
-      // All optional claims undefined
       expect(result.fullName).toBeUndefined();
       expect(result.email).toBeUndefined();
       expect(result.phoneNumber).toBeUndefined();
       expect(result.roles).toBeUndefined();
       expect(result.customClaims).toBeUndefined();
-
-      scope.done();
     });
   });
 
   describe('Required Claims Validation', () => {
-    test('Throws error when sub claim is missing', async () => {
+    test('Throws TypeError when sub claim is missing', async () => {
       const accessToken = 'valid-access-token';
       const invalidResponse = {
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // missing sub
       };
+      mockFetch(200, invalidResponse);
 
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(TypeError);
-        expect((error as TypeError).message).toBe('Invalid userinfo response: missing sub claim');
-      }
-
-      scope.done();
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow(
+        'Invalid userinfo response: missing sub claim'
+      );
     });
 
-    test('Throws error when tnt_id claim is missing', async () => {
+    test('Throws TypeError when tnt_id claim is missing', async () => {
       const accessToken = 'valid-access-token';
       const invalidResponse = {
         sub: 'user-123',
         app_id: 'app-789',
         idp_name: 'wristband',
-        // missing tnt_id
       };
+      mockFetch(200, invalidResponse);
 
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(TypeError);
-        expect((error as TypeError).message).toBe('Invalid userinfo response: missing tnt_id claim');
-      }
-
-      scope.done();
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow(
+        'Invalid userinfo response: missing tnt_id claim'
+      );
     });
 
-    test('Throws error when app_id claim is missing', async () => {
+    test('Throws TypeError when app_id claim is missing', async () => {
       const accessToken = 'valid-access-token';
       const invalidResponse = {
         sub: 'user-123',
         tnt_id: 'tenant-456',
         idp_name: 'wristband',
-        // missing app_id
       };
+      mockFetch(200, invalidResponse);
 
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(TypeError);
-        expect((error as TypeError).message).toBe('Invalid userinfo response: missing app_id claim');
-      }
-
-      scope.done();
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow(
+        'Invalid userinfo response: missing app_id claim'
+      );
     });
 
-    test('Throws error when idp_name claim is missing', async () => {
+    test('Throws TypeError when idp_name claim is missing', async () => {
       const accessToken = 'valid-access-token';
       const invalidResponse = {
         sub: 'user-123',
         tnt_id: 'tenant-456',
         app_id: 'app-789',
-        // missing idp_name
       };
+      mockFetch(200, invalidResponse);
 
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(TypeError);
-        expect((error as TypeError).message).toBe('Invalid userinfo response: missing idp_name claim');
-      }
-
-      scope.done();
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow(
+        'Invalid userinfo response: missing idp_name claim'
+      );
     });
 
-    test('Throws error when sub claim is not a string', async () => {
+    test('Throws TypeError when sub claim is not a string', async () => {
       const accessToken = 'valid-access-token';
       const invalidResponse = {
-        sub: 12345, // Not a string
+        sub: 12345,
         tnt_id: 'tenant-456',
         app_id: 'app-789',
         idp_name: 'wristband',
       };
+      mockFetch(200, invalidResponse);
 
-      const scope = nock(`https://${DOMAIN}`).get('/api/v1/oauth2/userinfo').reply(200, invalidResponse);
-
-      try {
-        await wristbandService.getUserInfo(accessToken);
-        fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(TypeError);
-        expect((error as TypeError).message).toBe('Invalid userinfo response: missing sub claim');
-      }
-
-      scope.done();
+      await expect(wristbandService.getUserInfo(accessToken)).rejects.toThrow(
+        'Invalid userinfo response: missing sub claim'
+      );
     });
   });
 });


### PR DESCRIPTION
# Release v6.1.0

## New Features

### ✨ IDP Hint Support
The `login()` flow now forwards the `idp_hint` query parameter to the Wristband Authorize Endpoint when present. This allows applications to bypass the Wristband-hosted Tenant Login Page and send users directly to a specific identity provider.

**Behavior:**
- Matching external IDP — redirects user straight to that IDP's login page (e.g. Google)
- Wristband IDP name — shows only the Wristband login form, no external IDP buttons
- Unrecognized or invalid value — ignored, login page displays as normal

## Bug Fixes

### 🐛 Fix: Explicit `redirectUri` no longer fails when OAuth2 client has multiple redirect URIs
Previously, providing `redirectUri` explicitly in the SDK config would still throw an error during auto-configuration if the Wristband OAuth2 client had multiple redirect URIs configured (causing the endpoint to return `null`). The SDK now correctly uses the manually provided value and skips the null endpoint response.

## Improvements

### 🔧 Removed `axios` Dependency
Replaced `axios` with Node 20's built-in `fetch` API. No behavior changes; purely an internal refactor to eliminate a third-party HTTP client dependency.