### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://wristband.dev",
   "repository": {
     "type": "git",
-    "url": "git@github.com:wristband-dev/express-auth.git"
+    "url": "git+https://github.com/wristband-dev/express-auth.git"
   },
   "bugs": {
     "email": "support@wristband.dev"


### PR DESCRIPTION
## Summary

Updates the package repository metadata from the SSH GitHub URL to the equivalent public HTTPS GitHub URL.

## Why

`@wristband/express-auth` is a public npm package, but `package.json` currently advertises the repository as `git@github.com:wristband-dev/express-auth.git`. Using the `git+https` form lets npm consumers and metadata tooling resolve the public source repository without requiring GitHub SSH configuration.

No runtime code, dependency, lockfile, package version, `bugs`, or `homepage` fields are changed.

## Validation

- Verified `package.json` parses and keeps the expected `bugs` and `homepage` values
- `npm pack --dry-run --ignore-scripts --json .`
- `npm test` (25 suites, 650 tests passed)
- `git diff --check`